### PR TITLE
Make tests generation optional and other fixes

### DIFF
--- a/sdk/python/core/docsgen/about_ydk.rst
+++ b/sdk/python/core/docsgen/about_ydk.rst
@@ -1,7 +1,9 @@
 About YDK
 =========
 
-This ydk-py is generated using `ydk-gen <https://github.com/CiscoDevNet/ydk-gen>`_
+Version : version-id
+
+This ydk-py is generated using `ydk-gen <https://github.com/CiscoDevNet/ydk-gen>`_.
 
 To check out the version of ydk-gen used to generate this ydk-py, use the below commands:
 

--- a/sdk/python/core/ydk/services/netconf_service.py
+++ b/sdk/python/core/ydk/services/netconf_service.py
@@ -26,8 +26,11 @@ try:
     from ydk.models.ietf import ietf_netconf
     from ydk.models.ietf import ietf_netconf_with_defaults
 except:
-    from ydk.models import ietf_netconf
-    from ydk.models import ietf_netconf_with_defaults
+    try:
+        from ydk.models import ietf_netconf
+        from ydk.models import ietf_netconf_with_defaults
+    except:
+        pass
 
 from ydk.types import Empty
 import logging

--- a/test/travis_ci.sh
+++ b/test/travis_ci.sh
@@ -398,7 +398,7 @@ cp_fxs $YDKGEN_HOME/yang/ydktest $DEVIATION_DEST_FXS
 cp_fxs $YDKGEN_HOME/yang/ydktest $AUGMENTATION_DEST_FXS
 cp_fxs $YDKGEN_HOME/yang/ydktest $YDKTEST_MODEL_DEST_FXS
 init_confd $YDKTEST_DEST_FXS
-run_pygen_test
+#run_pygen_test
 generate_ydktest_package
 run_sanity_tests
 submit_coverage

--- a/ydkgen/common.py
+++ b/ydkgen/common.py
@@ -120,7 +120,7 @@ def merge_file_path_segments(segs):
 
 
 def iskeyword(word):
-    return keyword.iskeyword(word) or word in ('None', 'parent')
+    return keyword.iskeyword(word) or word in ('None', 'parent', 'operator')
 
 
 def get_sphinx_ref_label(named_element):

--- a/ydkgen/printer/cpp/cpp_bindings_printer.py
+++ b/ydkgen/printer/cpp/cpp_bindings_printer.py
@@ -26,8 +26,8 @@ from .source_printer import SourcePrinter
 
 class CppBindingsPrinter(LanguageBindingsPrinter):
 
-    def __init__(self, ydk_root_dir, bundle_name, sort_clazz):
-        super(CppBindingsPrinter, self).__init__(ydk_root_dir, bundle_name, sort_clazz)
+    def __init__(self, ydk_root_dir, bundle_name, generate_tests, sort_clazz):
+        super(CppBindingsPrinter, self).__init__(ydk_root_dir, bundle_name, generate_tests, sort_clazz)
 
     def print_files(self):
         only_modules = [package.stmt for package in self.packages]

--- a/ydkgen/printer/language_bindings_printer.py
+++ b/ydkgen/printer/language_bindings_printer.py
@@ -37,11 +37,12 @@ class _EmitArgs:
 
 class LanguageBindingsPrinter(object):
 
-    def __init__(self, ydk_root_dir, bundle_name, sort_clazz=False):
+    def __init__(self, ydk_root_dir, bundle_name, generate_tests, sort_clazz=False):
         self.ydk_dir = os.path.join(ydk_root_dir, 'ydk')
         self.ydk_doc_dir = os.path.join(ydk_root_dir, 'docsgen')
         self.bundle_name = bundle_name
         self.sort_clazz = sort_clazz
+        self.generate_tests = generate_tests
 
     def emit(self, packages):
         self.ypy_ctx = None

--- a/ydkgen/printer/python/doc_printer.py
+++ b/ydkgen/printer/python/doc_printer.py
@@ -51,7 +51,7 @@ class DocPrinter(object):
         if bundle_name == '':
             title = 'YDK Model API'
         else:
-            title = 'YDK {0} bundle API'.format(bundle_name)
+            title = 'YDK {0} Bundle API'.format(bundle_name)
         self._print_title(title)
         self._print_toctree(packages, is_package=True)
 

--- a/ydkgen/printer/python/python_bindings_printer.py
+++ b/ydkgen/printer/python/python_bindings_printer.py
@@ -38,8 +38,8 @@ from ydkgen.printer.language_bindings_printer import LanguageBindingsPrinter, _E
 
 class PythonBindingsPrinter(LanguageBindingsPrinter):
 
-    def __init__(self, ydk_root_dir, bundle_name, sort_clazz):
-        super(PythonBindingsPrinter, self).__init__(ydk_root_dir, bundle_name, sort_clazz)
+    def __init__(self, ydk_root_dir, bundle_name, generate_tests, sort_clazz):
+        super(PythonBindingsPrinter, self).__init__(ydk_root_dir, bundle_name, generate_tests, sort_clazz)
 
     def print_files(self):
         self.print_init_file(self.models_dir)
@@ -90,7 +90,8 @@ class PythonBindingsPrinter(LanguageBindingsPrinter):
         # RST Documentation
         self.print_python_module(package, index, module_dir, size, sub)
         self.print_meta_module(package, meta_dir)
-        self.print_test_module(package, test_output_dir)
+        if self.generate_tests:
+            self.print_test_module(package, test_output_dir)
         if self.ydk_doc_dir is not None:
             self.print_python_rst_module(package)
 

--- a/ydkgen/resolver/bundle_resolver.py
+++ b/ydkgen/resolver/bundle_resolver.py
@@ -236,9 +236,10 @@ class Resolver(object):
 
     """
 
-    def __init__(self, output_dir, reuse_model=False, reuse_bundle=False):
+    def __init__(self, output_dir, root_dir, reuse_model=False, reuse_bundle=False):
         """ Initialize cached file directories.
         """
+        self.root_dir = root_dir
         self.cached_models_dir = ''
         self.cached_bundles_dir = ''
         self.bundles = {}
@@ -322,7 +323,7 @@ class Resolver(object):
         """
         tmp_file = tempfile.mkstemp('')[-1]
         try:
-            translate(description_file, tmp_file)
+            translate(description_file, tmp_file, self.root_dir)
         except KeyError:
             os.remove(tmp_file)
             return description_file

--- a/ydkgen/resolver/bundle_translator.py
+++ b/ydkgen/resolver/bundle_translator.py
@@ -162,13 +162,6 @@ def get_git_attrs(repos, root, remote=None):
         rmtree(tmp_dir)
 
 
-def check_envs():
-    if 'YDKGEN_HOME' not in os.environ:
-        logger.error('YDKGEN_HOME not set.')
-        print >> sys.stderr, "Need to have YDKGEN_HOME set!"
-        sys.exit(1)
-
-
 def load_profile_attr(profile_file, attr):
     with open(profile_file) as f:
         data = json.load(f)
@@ -184,12 +177,11 @@ def load_profile_attr(profile_file, attr):
         return None
 
 
-def translate(in_file, out_file):
+def translate(in_file, out_file, root_dir):
     """ Generate bundle file using profile file(in_file).
     in_file is a relative path to a local profile file.
     """
-    check_envs()
-    ydk_root = os.path.expandvars('$YDKGEN_HOME')
+    ydk_root = root_dir
 
     with open(in_file) as f:
         data = json.load(f)
@@ -216,8 +208,6 @@ def translate(in_file, out_file):
 
 if __name__ == '__main__':
 
-    check_envs()
-
     # init option parser
     parser = OptionParser(usage="usage: %prog [options]")
 
@@ -226,6 +216,10 @@ if __name__ == '__main__':
                       dest="verbose",
                       default=False,
                       help="Verbose mode")
+    parser.add_option("-r", "--root",
+                      type=str,
+                      dest="root",
+                      help="Root directory")
 
     (options, args) = parser.parse_args()
 
@@ -236,7 +230,7 @@ if __name__ == '__main__':
         logger.setLevel(logging.DEBUG)
 
     # init dirs
-    ydk_root = os.path.expandvars('$YDKGEN_HOME')
+    ydk_root = options.root
     profiles_root = os.path.join(ydk_root, 'profiles')
     bundles_root = os.path.join(ydk_root, 'bundles')
     if os.path.isdir(bundles_root):


### PR DESCRIPTION
 * Introduce --generate-tests option to generate model tests if needed
 * Copy bundle docs to core docs when generating core docs and add to main ToC
 * Show time taken for generation
 * Print version number in 'About YDK' page
 * Pass in ydk root directory to bundle resolver instead of looking at YDKGEN_HOME env
 * Temporarily disable pygen_test