### PR TITLE
Added datastore option check (#252)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update && sudo apt-get install -y python-pip zlib1g-dev python-lxml libxml2-dev libxslt1-dev python-dev libboost-dev libboost-python-dev libssh-dev libcurl4-openssl-dev libtool python3-lxml; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python boost-python jq ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install jq ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$PATH:~/Library/Python; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull ydkdev/confd-beta; fi
 

--- a/sdk/python/core/tests/test_sanity_netconf.py
+++ b/sdk/python/core/tests/test_sanity_netconf.py
@@ -161,6 +161,46 @@ class SanityNetconf(unittest.TestCase):
                           self.ncc,
                           Datastore.candidate)
 
+    def test_copy_config_fail(self):
+        self.assertRaises(YPYServiceError,
+                          self.netconf_service.copy_config,
+                          self.ncc,
+                          target=123,
+                          source=456)
+
+    def test_edit_config_fail(self):
+        self.assertRaises(YPYServiceError,
+                          self.netconf_service.edit_config,
+                          self.ncc,
+                          Datastore.startup,
+                          Datastore.candidate)
+
+    def test_get_config_fail(self):
+        runner = ysanity.Runner()
+        self.assertRaises(YPYServiceError,
+                        self.netconf_service.get_config,
+                        self.ncc,
+                        "invalid-input",
+                        runner)
+
+    def test_lock_fail(self):
+        self.assertRaises(YPYServiceError,
+                          self.netconf_service.lock,
+                          self.ncc,
+                          "invalid-input")
+
+    def test_unlock_fail(self):
+        self.assertRaises(YPYServiceError,
+                          self.netconf_service.unlock,
+                          self.ncc,
+                          "invalid-input")
+
+    def test_validate_fail(self):
+        self.assertRaises(YPYServiceError,
+                          self.netconf_service.validate,
+                          self.ncc,
+                          source=123)
+
 
 if __name__ == '__main__':
     import sys

--- a/sdk/python/core/tests/test_sanity_netconf.py
+++ b/sdk/python/core/tests/test_sanity_netconf.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import unittest
 from compare import is_equal
 
-from ydk.errors import YPYModelError, YPYError
+from ydk.errors import YPYModelError, YPYError, YPYServiceError
 from ydk.models import ydktest_sanity as ysanity
 from ydk.providers import NetconfServiceProvider, NativeNetconfServiceProvider
 from ydk.services import NetconfService
@@ -144,6 +144,22 @@ class SanityNetconf(unittest.TestCase):
     def test_copy_config(self):
         op = self.netconf_service.copy_config(self.ncc, Datastore.candidate, Datastore.running)
         self.assertIn('ok', op)
+
+    def test_delete_config(self):
+        pass
+        # startup and candidate cannot be both enabled in ConfD
+        # op = self.netconf_service.delete_config(self.ncc, Datastore.startup)
+        # self.assertIn('ok', op)
+
+    def test_delete_config_fail(self):
+        self.assertRaises(YPYServiceError,
+                          self.netconf_service.delete_config,
+                          self.ncc,
+                          Datastore.running)
+        self.assertRaises(YPYServiceError,
+                          self.netconf_service.delete_config,
+                          self.ncc,
+                          Datastore.candidate)
 
 
 if __name__ == '__main__':

--- a/sdk/python/core/ydk/services/netconf_service.py
+++ b/sdk/python/core/ydk/services/netconf_service.py
@@ -18,7 +18,6 @@
    The Netconf Service class.
 
 """
-from .._core._dm_meta_info import ANYXML_CLASS
 from .executor_service import ExecutorService
 from .service import Service
 from enum import Enum

--- a/sdk/python/core/ydk/services/netconf_service.py
+++ b/sdk/python/core/ydk/services/netconf_service.py
@@ -18,6 +18,7 @@
    The Netconf Service class.
 
 """
+from .._core._dm_meta_info import ANYXML_CLASS
 from .executor_service import ExecutorService
 from .service import Service
 from enum import Enum
@@ -178,6 +179,8 @@ class NetconfService(Service):
         self.service_logger.info('Executing copy-config RPC')
 
         rpc = ietf_netconf.CopyConfigRpc()
+        _validate_datastore_options(source, 'copy-config:source')
+        _validate_datastore_options(target, 'copy-config:target')
         rpc.input.source = _get_rpc_datastore_object(source, rpc.input.source)
         rpc.input.target = _get_rpc_datastore_object(target, rpc.input.target)
         rpc.input.with_defaults_option = with_defaults_option
@@ -205,6 +208,7 @@ class NetconfService(Service):
         self.service_logger.info('Executing delete-config RPC')
 
         rpc = ietf_netconf.DeleteConfigRpc()
+        _validate_datastore_options(target, 'delete-config:target')
         rpc.input.target = _get_rpc_datastore_object(target, rpc.input.target)
 
         return self.executor.execute_rpc(provider, rpc)
@@ -267,6 +271,7 @@ class NetconfService(Service):
         self.service_logger.info('Executing edit-config RPC')
 
         rpc = ietf_netconf.EditConfigRpc()
+        _validate_datastore_options(target, 'edit-config:target')
         rpc.input.target = _get_rpc_datastore_object(target, rpc.input.target)
         rpc.input.config = config
         rpc.input.default_operation = default_operation
@@ -304,6 +309,7 @@ class NetconfService(Service):
 
         rpc = ietf_netconf.GetConfigRpc()
         rpc.input.filter = get_filter
+        _validate_datastore_options(source, 'get-config:source')
         rpc.input.source = _get_rpc_datastore_object(source, rpc.input.source)
         rpc.input.with_defaults_option = with_defaults_option
 
@@ -384,6 +390,7 @@ class NetconfService(Service):
         self.service_logger.info('Executing lock RPC')
 
         rpc = ietf_netconf.LockRpc()
+        _validate_datastore_options(target, 'lock:target')
         rpc.input.target = _get_rpc_datastore_object(target, rpc.input.target)
 
         return self.executor.execute_rpc(provider, rpc)
@@ -410,6 +417,7 @@ class NetconfService(Service):
         self.service_logger.info('Executing unlock RPC')
 
         rpc = ietf_netconf.UnlockRpc()
+        _validate_datastore_options(target, 'unlock:target')
         rpc.input.target = _get_rpc_datastore_object(target, rpc.input.target)
 
         return self.executor.execute_rpc(provider, rpc)
@@ -437,6 +445,7 @@ class NetconfService(Service):
 
         rpc = ietf_netconf.ValidateRpc()
         if source is not None:
+            _validate_datastore_options(source, 'validate:source')
             rpc.input.source = _get_rpc_datastore_object(source, rpc.input.source)
         if config is not None:
             rpc.input.source.config = config
@@ -467,3 +476,43 @@ def payload_convert(payload):
     rt = etree.fromstring(payload.encode('utf-8'))
     chchs = rt.getchildren()[0].getchildren()
     return etree.tostring(chchs[0], pretty_print=True, encoding='utf-8').decode('utf-8')
+
+
+def _validate_datastore_options(datastore, option):
+    res = True
+    if option == 'copy-config:target':
+        res = isinstance(datastore, (str, Datastore))
+    elif option == 'copy-config:source':
+        res = isinstance(datastore, (str, Datastore)) or _is_anyxml(datastore)
+    elif option == 'delete-config:target':
+        res = isinstance(datastore, str) or datastore == Datastore.startup
+    elif option == 'edit-config:target':
+        res = datastore in (Datastore.candidate, Datastore.running)
+    elif option == 'get-config:source':
+        res = isinstance(datastore, Datastore)
+    elif option == 'lock:target':
+        res = isinstance(datastore, Datastore)
+    elif option == 'unlock:target':
+        res = isinstance(datastore, Datastore)
+    elif option == 'validate:source':
+        res = isinstance(datastore, (str, Datastore)) or _is_anyxml(datastore)
+
+    if not res:
+        err_msg = _get_datastore_errmsg(option, datastore)
+        raise YPYServiceError(error_msg=err_msg)
+
+
+def _is_anyxml(datastore):
+    return hasattr(datastore, 'i_meta') and datastore.i_meta.mtype == ANYXML_CLASS
+
+
+def _get_datastore_errmsg(option, datastore):
+    if isinstance(datastore, Datastore):
+        pass
+    elif isinstance(datastore, str):
+        datastore = 'url'
+    elif _is_anyxml(datastore):
+        datastore = 'anyxml'
+    if ':' in option:
+        option = option[:option.find(':')]
+    return "%s datastore is not supported by Netconf %s operation" % (datastore, option)

--- a/sdk/python/core/ydk/services/netconf_service.py
+++ b/sdk/python/core/ydk/services/netconf_service.py
@@ -483,7 +483,7 @@ def _validate_datastore_options(datastore, option):
     if option == 'copy-config:target':
         res = isinstance(datastore, (str, Datastore))
     elif option == 'copy-config:source':
-        res = isinstance(datastore, (str, Datastore)) or _is_anyxml(datastore)
+        res = isinstance(datastore, (str, Datastore))
     elif option == 'delete-config:target':
         res = isinstance(datastore, str) or datastore == Datastore.startup
     elif option == 'edit-config:target':
@@ -495,15 +495,11 @@ def _validate_datastore_options(datastore, option):
     elif option == 'unlock:target':
         res = isinstance(datastore, Datastore)
     elif option == 'validate:source':
-        res = isinstance(datastore, (str, Datastore)) or _is_anyxml(datastore)
+        res = isinstance(datastore, (str, Datastore))
 
     if not res:
         err_msg = _get_datastore_errmsg(option, datastore)
         raise YPYServiceError(error_msg=err_msg)
-
-
-def _is_anyxml(datastore):
-    return hasattr(datastore, 'i_meta') and datastore.i_meta.mtype == ANYXML_CLASS
 
 
 def _get_datastore_errmsg(option, datastore):
@@ -511,8 +507,6 @@ def _get_datastore_errmsg(option, datastore):
         pass
     elif isinstance(datastore, str):
         datastore = 'url'
-    elif _is_anyxml(datastore):
-        datastore = 'anyxml'
     if ':' in option:
         option = option[:option.find(':')]
     return "%s datastore is not supported by Netconf %s operation" % (datastore, option)


### PR DESCRIPTION
Disabled delete config test case in test_sanity_netconf.py because ConfD
does not support startup and candidate datastore at the same time.