### PR TITLE
NetconfService Issues (#248), (#247), (#235)

### DIFF
--- a/sdk/python/core/docsgen/ydk.services.rst
+++ b/sdk/python/core/docsgen/ydk.services.rst
@@ -2,7 +2,7 @@ ydk.services module
 ===================
 
 .. toctree::
-	:maxdepth: 1
+    :maxdepth: 1
 
 .. py:currentmodule:: ydk.services
 
@@ -12,429 +12,452 @@ The Services module. Supported services include
 
 CRUDService: Provides Create/Read/Update/Delete API's
 -------------------------------------------------------
-		
+
 .. py:class:: ydk.services.CRUDService
 
-		Bases: :class:`ydk.services.Service`
-		
-		CRUD Service class for supporting CRUD operations on entities.
-		
-		.. py:method:: create(provider, entity)
-				
-				Create the entity
-				
-				:param provider: An instance of ydk.providers.ServiceProvider
-				:param entity: An instance of an entity class defined under the ydk.models package or subpackages.
-				
-				:return: None
+        Bases: :class:`ydk.services.Service`
 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred
-				:raises ydk.errors.YPYError: if other error has occurred
+        CRUD Service class for supporting CRUD operations on entities.
 
-				Possible Errors:
+        .. py:method:: create(provider, entity)
 
-				* a server side error
-				* there isn't enough information in the entity to prepare the message (eg. missing keys)
+                Create the entity
+
+                :param provider: An instance of ydk.providers.ServiceProvider
+                :param entity: An instance of an entity class defined under the ydk.models package or subpackages.
+
+                :return: None
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
+                :raises ydk.errors.YPYError: if other error has occurred
+
+                Possible Errors:
+
+                * a server side error
+                * there isn't enough information in the entity to prepare the message (eg. missing keys)
 
 
-		.. py:method:: read(provider, read_filter, only_config=False)
-				
-				Read the entity or entities.
-				
-				:param provider: An instance of ydk.providers.ServiceProvider
-				
-				:param read_filter: A read_filter is an instance of an entity class. An entity class is a class defined under the ydk.models package that is not an Enum, Identity or a subclass of FixedBitsDict). Attributes of this entity class may contain values that act as match expressions or can be explicitly marked as to be read by assigning an instance of type `ydk.types.READ` to them.
-				
-				:param only_config: Flag that indicates that only the data that represents configuration data is to be fetched. Default is set to False i.e both oper and config data will be fetched.
-				
-				
-				:return: The entity or list of entities as identified by the `read_filter`
-				
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred
-				:raises ydk.errors.YPYError: if other error has occurred
+        .. py:method:: read(provider, read_filter, only_config=False)
 
-				Possible errors could be
+                Read the entity or entities.
 
-				* a server side error
-				* if there isn't enough information in the entity to prepare the message (missing keys for example)
-				 
-				
-		.. py:method:: update(provider, entity)
-				
-				Update the entity.
-				
-				Note:
+                :param provider: An instance of ydk.providers.ServiceProvider
 
-				* An attribute of an entity class can be deleted by setting to an instance of `ydk.types.DELETE`.
-				* An entity can only be updated if it exists on the server. Otherwise a `ydk.errors.YPYError` will be raised.
-				
-				:param provider: An instance of ydk.providers.ServiceProvider
-				:param entity: An instance of an entity class defined under the ydk.models package or subpackages.
-				
-				:return: None
-				
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred
-				:raises ydk.errors.YPYError: if other error has occurred
+                :param read_filter: A read_filter is an instance of an entity class. An entity class is a class defined under the ydk.models package that is not an Enum, Identity or a subclass of FixedBitsDict). Attributes of this entity class may contain values that act as match expressions or can be explicitly marked as to be read by assigning an instance of type `ydk.types.READ` to them.
 
-				Possible errors could be
+                :param only_config: Flag that indicates that only the data that represents configuration data is to be fetched. Default is set to False i.e both oper and config data will be fetched.
 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
-								  
 
-		.. py:method:: delete(provider, entity)
-		
-				Delete the entity
-				
-				:param provider: An instance of ydk.providers.ServiceProvider
-				:param entity: An instance of an entity class defined under the ydk.models package or subpackages.
-				
-				:return: None
-				
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
+                :return: The entity or list of entities as identified by the `read_filter`
 
-				Possible errors could be
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
+                :raises ydk.errors.YPYError: if other error has occurred
 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
-				
+                Possible errors could be
+
+                * a server side error
+                * if there isn't enough information in the entity to prepare the message (missing keys for example)
+
+
+        .. py:method:: update(provider, entity)
+
+                Update the entity.
+
+                Note:
+
+                * An attribute of an entity class can be deleted by setting to an instance of `ydk.types.DELETE`.
+                * An entity can only be updated if it exists on the server. Otherwise a `ydk.errors.YPYError` will be raised.
+
+                :param provider: An instance of ydk.providers.ServiceProvider
+                :param entity: An instance of an entity class defined under the ydk.models package or subpackages.
+
+                :return: None
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
+                :raises ydk.errors.YPYError: if other error has occurred
+
+                Possible errors could be
+
+                * a server side error
+                * if there isn't enough information in the entity to the message (missing keys for example)
+
+
+        .. py:method:: delete(provider, entity)
+
+                Delete the entity
+
+                :param provider: An instance of ydk.providers.ServiceProvider
+                :param entity: An instance of an entity class defined under the ydk.models package or subpackages.
+
+                :return: None
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
+                :raises ydk.errors.YPYError: if other error has occurred
+
+                Possible errors could be
+
+                * a server side error
+                * if there isn't enough information in the entity to the message (missing keys for example)
+
 
 NetconfService: Provides API's to execute netconf operations
 --------------------------------------------------------------
 .. py:class:: ydk.services.Datastore
 
-	Bases: :class:`enum.Enum`
+    Bases: :class:`enum.Enum`
 
-	Netconf datastore type
+    Netconf datastore type
 
-	.. data:: candidate = 1
+    .. data:: candidate = 1
 
-		Candidate
+        Candidate
 
-	.. data:: running = 2
+    .. data:: running = 2
 
-		Running
+        Running
 
-	.. data:: startup = 3
+    .. data:: startup = 3
 
-		Startup
+        Startup
 
-	
+
 .. py:class:: ydk.services.NetconfService
 
-	Bases: :class:`ydk.services.Service`
-	
-	Netconf Service class for executing netconf operations.
+Bases: :py:class:`ydk.services.Service`.
 
-		.. py:method:: cancel_commit(provider, persist_id=None)
-		
-				Execute an cancel-commit operation to cancel an ongoing confirmed commit.
+Netconf Service class for executing netconf operations.
 
-				:param provider: An instance of ydk.providers.ServiceProvider
-				:param persist_id: This parameter is given in order to cancel a persistent confirmed commit. The value must be equal to the value given in the 'persist' parameter to the <commit> operation. If it does not match, the operation fails with an 'invalid-value' error
+        .. py:method:: cancel_commit(provider, persist_id=None)
 
-				:return: ok reply if operation succeeds else, raises an exception
+                Execute an cancel-commit operation to cancel an ongoing confirmed commit.
 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param str persist_id: This parameter is given in order to cancel a persistent confirmed commit. The value must be equal to the value given in the 'persist' parameter to the commit operation. If it does not match, the operation fails with an 'invalid-value' error.
 
-				Possible errors could be
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                :raises ydk.errors.YPYDataValidationError: If validation error has occurred.
+                :raises ydk.errors.YPYError: If other error has occurred. Possible errors could be:
 
-		.. py:method:: close_session(provider)
-		
-				Execute a close-session operation to cancel an ongoing confirmed commit.
- 
-				:param provider: An instance of ydk.providers.ServiceProvider
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                    * A server side error
+                    * If there isn't enough information in the entity to the message (missing keys for example).
 
-		.. py:method:: commit(provider)
-		
-				Execute a commit operation to commit the candidate configuration as the device's new current configuration.
- 
-				:param provider: An instance of ydk.providers.ServiceProvider
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+        .. py:method:: close_session(provider)
 
-		.. py:method:: commit_confirmed(provider, confirm_timeout=None, persist=False, persist_id=None)
-		
-				Execute a commit operation to commit the candidate configuration with a confirmed option.
- 
-				:param provider: An instance of ydk.providers.ServiceProvider
-				:param confirm_timeout: The timeout interval for a confirmed commit
-				:param persist: This parameter is used to make a confirmed commit persistent. A persistent confirmed commit is not aborted if the NETCONF session terminates.  The only way to abort a persistent confirmed commit is to let the timer expire, or to use the <cancel-commit> operation. The value of this parameter is a token that must be given in the 'persist-id' parameter of <commit> or <cancel-commit> operations in order to confirm or cancel the persistent confirmed commit.  The token should be a random string
-				:param persist_id: This parameter is given in order to commit a persistent confirmed commit. The value must be equal to the value given in the 'persist' parameter to the <commit> operation. If it does not match, the operation fails with an 'invalid-value' error
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
- 
-				return self.executor.execute_rpc(provider, rpc)
+                Execute a close-session operation to cancel an ongoing confirmed commit.
 
-		.. py:method:: copy_config(provider, target, source, with_defaults_option=None)
-		
-				Execute a copy-config operation to create or replace an entire configuration datastore with the contents of another complete configuration datastore.
- 
-				:param target: Particular configuration to copy to
-				:param source: Particular configuration to copy from
-				:param with_defaults: The explicit defaults processing mode requested
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
 
-		.. py:method:: delete_config(provider, target)
-		
-				Execute an delete-config operation to delete a configuration datastore.
- 
-				:param target: Particular configuration to delete
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
 
-		.. py:method:: discard_changes(provider)
-		
-				Execute a discard-changes operation to revert the candidate configuration to the current running configuration.
- 
-				:param provider: An instance of ydk.providers.ServiceProvider
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
+                :raises ydk.errors.YPYError: if other error has occurred.
 
-		.. py:method:: edit_config(provider, target, config, default_operation=None, error_option=None, test_option=None)
-		
-				Execute an edit-config operation to load all or part of a specified configuration to the specified target configuration.
- 
-				:param provider: An instance of ydk.providers.ServiceProvider
-				:param target: Particular configuration to edit
-				:param config: Inline Config content
-				:param default_operation: The default operation to use
-				:param error_option: The error option to use
-				:param test_option: The test option to use
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
- 
-				.. py:method:: get_config(provider, source, get_filter, with_defaults_option=None)
-				Execute a get-config operation to retrieve all or part of a specified configuration.
- 
-				:param get_filter: Subtree or XPath filter to use
-				:param source: Particular configuration to retrieve
-				:param with_defaults: The explicit defaults processing mode requested
- 
-				:return: Copy of the running datastore subset and/or state data that matched the filter criteria (if any). An empty data container indicates that the request did not produce any results
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                    Possible errors could be:
 
-		.. py:method:: get(provider, get_filter, with_defaults_option=None)
-		
-				Execute a get operation to retrieve running configuration and device state information.
- 
-				:param get_filter: This parameter specifies the portion of the system configuration and state data to retrieve
-				:param with_defaults: The explicit defaults processing mode requested
- 
-				:return: Copy of the running datastore subset and/or state data that matched the filter criteria (if any). An empty data container indicates that the request did not produce any results
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
 
-		.. py:method:: kill_session(provider, session_id)
-		
-				Execute a kill-session operation to force the termination of a NETCONF session.
- 
-				:param session_id: Particular session to kill
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+        .. py:method:: commit(provider, confirmed=False, confirm_timeout=None, persist=False, persist_id=None)
 
-		.. py:method:: lock(provider, target)
-		
-				Execute a lock operation to allow the client to lock the configuration system of a device.
- 
-				:param target: Particular configuration to lock
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                Execute a commit operation to commit the candidate configuration as the device's new current configuration.
 
-		.. py:method:: unlock(provider, target)
-		
-				Execute an unlock operation to	release a configuration lock, previously obtained with the 'lock' operation.
- 
-				:param target: Particular configuration to unlock
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param bool confirmed: Perform a confirmed commit operation.
+                :param int confirm_timeout: The timeout interval for a confirmed commit.
+                :param str persist: Make a confirmed commit persistent. A persistent confirmed commit is not aborted if the NETCONF session terminates. The only way to abort a persistent confirmed commit is to let the timer expire, or to use the <cancel-commit> operation. The value of this parameter is a token that must be given in the 'persist-id' parameter of <commit> or <cancel-commit> operations in order to confirm or cancel the persistent confirmed commit. The token should be a random string.
+                :param str persist_id: This parameter is given in order to commit a persistent confirmed commit. The value must be equal to the value given in the 'persist' parameter to the <commit> operation. If it does not match, the operation fails with an 'invalid-value' error.
 
-		.. py:method:: validate(provider, source=None, config=None)
-		
-				Execute a validate operation to validate the contents of the specified configuration.
- 
-				:param source: Particular configuration to validate
-				:param with_defaults: The explicit defaults processing mode requested
- 
-				:return: ok reply if operation succeeds else, raises an exception
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred 
-				:raises ydk.errors.YPYError: if other error has occurred
- 
-				Possible errors could be
- 
-				* a server side error
-				* if there isn't enough information in the entity to the message (missing keys for example)
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
 
-				
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: copy_config(provider, target, source, with_defaults_option=None)
+
+                Execute a copy-config operation to create or replace an entire configuration datastore with the contents of another complete configuration datastore.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param target: Particular configuration to copy to. Valid options are :py:attr:`.Datastore.candidate`, :py:attr:`.Datastore.running`, :py:attr:`.Datastore.startup` and url(``str``) if the device has such feature advertised in device capability.
+                :param source: Particular configuration to copy from. Valid options are :py:attr:`.Datastore.candidate`, :py:attr:`.Datastore.running`, :py:attr:`.Datastore.startup` and url(``str``) if the deivce has such feature advertised in capability. YDK entity object could also be used as a config block for this parameter.
+                :param with_defaults: The explicit defaults processing mode requested.
+                :type with_defaults: :py:attr:`ietf_netconf.WithDefaultsModeEnum`
+
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: delete_config(provider, target)
+
+                Execute an delete-config operation to delete a configuration datastore.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param target: Particular configuration to delete. Valid options are :py:attr:`.Datastore.startup` or url(``str``).
+
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: discard_changes(provider)
+
+                Execute a discard-changes operation to revert the candidate configuration to the current running configuration.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: edit_config(provider, target, config, default_operation=None, error_option=None, test_option=None)
+
+                Execute an edit-config operation to load all or part of a specified configuration to the specified target configuration.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param target: Particular configuration to copy from. Valid options are :py:attr:`.Datastore.candidate`, :py:attr:`.Datastore.running`.
+                :param config: A YDK entity object used as a config block.
+                :param default_operation: Selects the default operation for this edit-config request.
+                :type default_operation: :py:class:`EditConfigRpc.Input.DefaultOperationEnum`
+                :param error_option: Selects the error option for this edit-config request.
+                :type error_option: :py:class:`EditConfigRpc.Input.ErrorOptionEnum`
+                :param test_option: Selects the test option for this edit-config request.
+                :type test_option: :py:class:`EditConfigRpc.Input.TestOptionEnum`
+
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: get_config(provider, source, get_filter, with_defaults_option=None)
+
+                Execute a get-config operation to retrieve all or part of a specified configuration.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param get_filter:  A YDK entity object used as a subtree filter or XPath filter.
+                :param source: Particular configuration to retrieve. Valid options are :py:attr:`.Datastore.candidate`, :py:attr:`.Datastore.running`, and :py:attr:`.Datastore.startup`.
+                :param with_defaults: The explicit defaults processing mode requested.
+                :type with_defaults: :py:attr:`ietf_netconf.WithDefaultsModeEnum`
+
+                :return: A YDK entity object represents copy of the running datastore subset and/or state data that matched the filter criteria (if any). An empty data container indicates that the request did not produce any results.
+                :rtype: object
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: get(provider, get_filter, with_defaults_option=None)
+
+                Execute a get operation to retrieve running configuration and device state information.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param get_filter: This parameter specifies the portion of the system configuration and state data to retrieve.
+                :param with_defaults: The explicit defaults processing mode requested.
+                :type with_defaults: :py:attr:`ietf_netconf.WithDefaultsModeEnum`
+
+                :return: A YDK entity object represents copy of the running datastore subset and/or state data that matched the filter criteria (if any). An empty data container indicates that the request did not produce any results.
+                :rtype: object
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: kill_session(provider, session_id)
+
+                Execute a kill-session operation to force the termination of a NETCONF session.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param int session_id: Particular session to kill.
+
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: lock(provider, target)
+
+                Execute a lock operation to allow the client to lock the configuration system of a device.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param target: Particular configuration to lock. Valid options are :py:attr:`.Datastore.candidate`, :py:attr:`.Datastore.running`, and :py:attr:`.Datastore.startup` if the device has such feature advertised.
+
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: unlock(provider, target)
+
+                Execute an unlock operation to  release a configuration lock, previously obtained with the 'lock' operation.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param target: Particular configuration to unlock. Valid options are :py:attr:`.Datastore.candidate`, :py:attr:`.Datastore.running`, and :py:attr:`.Datastore.startup` if the device has such feature advertised.
+
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
+                :raises ydk.errors.YPYError: if other error has occurred
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+        .. py:method:: validate(provider, source=None, config=None)
+
+                Execute a validate operation to validate the contents of the specified configuration.
+
+                :param provider: A provider instance.
+                :type provider: ydk.providers.ServiceProvider
+                :param source: Particular configuration to validate. Valid options are :py:attr:`.Datastore.candidate`, :py:attr:`.Datastore.running`, :py:attr:`.Datastore.startup` and url(``str``) if the deivce has such feature advertised in device capability. YDK entity object could also be used as a config block for this parameter.
+                :param with_defaults: The explicit defaults processing mode requested.
+                :type with_defaults: :py:attr:`ietf_netconf.WithDefaultsModeEnum`
+
+                :return: An ok reply string if operation succeeds.
+                :rtype: str
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred.
+                :raises ydk.errors.YPYError: if other error has occurred.
+
+                    Possible errors could be:
+
+                    * A server side error.
+                    * If there isn't enough information in the entity to the message (missing keys for example).
+
+
 CodecService: Provides encode/decode API's
 --------------------------------------------
-		
+
 .. py:class:: ydk.services.CodecService
 
-		Bases: :class:`ydk.services.Service`
+        Bases: :class:`ydk.services.Service`
 
-		Codec Service class for supporting encoding entities and decoding payloads.
+        Codec Service class for supporting encoding entities and decoding payloads.
 
-		.. py:method:: encode(provider, entity)
-		
-				Encodes the python entity and returns the payload. Entity is either:
-				  - an instance of an entity class defined under the ydk.models package or subpackages, or
-				  - a dictionary containing:
-				     - module names as keys and
-				     - entity instances as values
-				
-				:return: encoded value can be:
-				  - an instance of an XML payload defined for a yang module, or
-                  - a dictionary containing:
-                     - module names as keys and
-                     - instances of XML payload defined for a yang module as values
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred
-				
-		.. py:method:: decode(provider, payload)
-		
-				Decodes the the payload and returns the python entity. Entity is either:
-				  - an instance of an XML payload defined for a yang module, or
-				  - a dictionary containing:
-				     - module names as keys and
-				     - instances of XML payload defined for a yang module as values
-				
-				:return: decoded entity. Entity is either:
+        .. py:method:: encode(provider, entity)
+
+                Encodes the python entity and returns the payload. Entity is either:
                   - an instance of an entity class defined under the ydk.models package or subpackages, or
                   - a dictionary containing:
                      - module names as keys and
                      - entity instances as values
- 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred
+
+                :return: encoded value can be:
+                  - an instance of an XML payload defined for a yang module, or
+                  - a dictionary containing:
+                     - module names as keys and
+                     - instances of XML payload defined for a yang module as values
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
+
+        .. py:method:: decode(provider, payload)
+
+                Decodes the the payload and returns the python entity. Entity is either:
+                  - an instance of an XML payload defined for a yang module, or
+                  - a dictionary containing:
+                     - module names as keys and
+                     - instances of XML payload defined for a yang module as values
+
+                :return: decoded entity. Entity is either:
+                  - an instance of an entity class defined under the ydk.models package or subpackages, or
+                  - a dictionary containing:
+                     - module names as keys and
+                     - entity instances as values
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
 
 
 ExecutorService: Provides API to execute RPCs
 ---------------------------------------------
-		
+
 .. py:class:: ydk.services.ExecutorService
 
-		Bases: :class:`ydk.services.Service`
-		
-		Executor Service class for supporting execution of RPCs.
-		
-		.. py:method:: execute_rpc(self, provider, rpc):
-				
-				Create the entity
-				
-				:param provider: An instance of ydk.providers.ServiceProvider
-				:param rpc: An instance of an RPC class defined under the ydk.models package or subpackages
-				
-				:return: None
+        Bases: :class:`ydk.services.Service`
 
-				:raises ydk.errors.YPYDataValidationError: if validation error has occurred
-				:raises ydk.errors.YPYError: if other error has occurred
+        Executor Service class for supporting execution of RPCs.
 
-				Possible Errors:
+        .. py:method:: execute_rpc(self, provider, rpc):
 
-				* a server side error
-				* there isn't enough information in the entity to prepare the message (eg. missing keys)
+                Create the entity
+
+                :param provider: An instance of ydk.providers.ServiceProvider
+                :param rpc: An instance of an RPC class defined under the ydk.models package or subpackages
+
+                :return: None
+
+                :raises ydk.errors.YPYDataValidationError: if validation error has occurred
+                :raises ydk.errors.YPYError: if other error has occurred
+
+                Possible Errors:
+
+                * a server side error
+                * there isn't enough information in the entity to prepare the message (eg. missing keys)
 
 
 
@@ -443,24 +466,24 @@ MetaService: Provide deviation validation capability
 
 .. py:class:: ydk.services.MetaService
 
-		Bases: :class:`ydk.services.Service`
+        Bases: :class:`ydk.services.Service`
 
-		Meta Service class to modify entity meta at run time.
+        Meta Service class to modify entity meta at run time.
 
-		.. py:classmethod:: normalize_meta(cls, capabilities, entity)
+        .. py:classmethod:: normalize_meta(cls, capabilities, entity)
 
-				Get meta information from entity._meta_info(), modify and inject i_meta attribute back to entity.
+                Get meta information from entity._meta_info(), modify and inject i_meta attribute back to entity.
 
-				:return: entity with i_meta injected
+                :return: entity with i_meta injected
 
-				:raises ydk.errors.YPYDataValidationError: if try to access an unsupported feature
+                :raises ydk.errors.YPYDataValidationError: if try to access an unsupported feature
 
-		.. py:classmethod:: get_active_deviation_tables(cls, capabilities, entity)
+        .. py:classmethod:: get_active_deviation_tables(cls, capabilities, entity)
 
-				Return active deviation tables
+                Return active deviation tables
 
-				:return: a dictionary for deviation tables
+                :return: a dictionary for deviation tables
 
-		.. py:classmethod:: inject_imeta(cls, entity, deviation_tables)
+        .. py:classmethod:: inject_imeta(cls, entity, deviation_tables)
 
-				Inject i_meta to entity using existing deviation table
+                Inject i_meta to entity using existing deviation table

--- a/sdk/python/core/tests/test_sanity_service_errors.py
+++ b/sdk/python/core/tests/test_sanity_service_errors.py
@@ -703,19 +703,11 @@ class SanityNetconf(unittest.TestCase):
         try:
             op = self.netconf_service.validate(self.ncc)
         except YPYServiceError as err:
-            expected_msg = "'source' and 'config' cannot be None"
+            expected_msg = "'source' cannot be None"
             self.assertEqual(err.message, expected_msg)
         else:
             raise Exception('YPYServiceError not raised')
 
-    def test_something(self):
-        try:
-            op = self.netconf_service.validate(self.ncc)
-        except YPYServiceError as err:
-            expected_msg = "'source' and 'config' cannot be None"
-            self.assertEqual(err.message, expected_msg)
-        else:
-            raise Exception('YPYServiceError not raised')
 
 if __name__ == '__main__':
     import sys

--- a/sdk/python/core/ydk/services/netconf_service.py
+++ b/sdk/python/core/ydk/services/netconf_service.py
@@ -37,38 +37,39 @@ import logging
 
 
 class Datastore(Enum):
-    '''
-    Type of datastore
-    '''
+    """Type of datastore."""
     candidate = 1
     running = 2
     startup = 3
 
 
 class NetconfService(Service):
-    """ Netconf Service class for executing netconf operations """
+    """Netconf Service class for executing netconf operations."""
 
     def __init__(self):
         self.executor = ExecutorService()
         self.service_logger = logging.getLogger(__name__)
 
     def cancel_commit(self, provider, persist_id=None):
-        """ Execute an cancel-commit operation to cancel an ongoing confirmed commit.
+        """Execute an cancel-commit operation to cancel an ongoing confirmed commit.
 
-            Args:
-                - provider: An instance of ydk.providers.ServiceProvider
-                - persist_id: This parameter is given in order to cancel a persistent confirmed commit.
-                    The value must be equal to the value given in the 'persist' parameter to the <commit>
-                    operation. If it does not match, the operation fails with an 'invalid-value' error
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            persist_id (str): Cancels a persistent confirmed commit. The value
+                MUST be equal to the value given in the <persist> parameter to
+                the <commit> operation. If the value does not match, the
+                operation fails with an "invalid-value" error.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         self.service_logger.info('Executing cancel-commit RPC')
 
@@ -78,99 +79,105 @@ class NetconfService(Service):
         return self.executor.execute_rpc(provider, rpc)
 
     def close_session(self, provider):
-        """ Execute a close-session operation to cancel an ongoing confirmed commit.
+        """Execute a close-session operation to cancel an ongoing confirmed commit.
 
-            Args:
-                - provider: An instance of ydk.providers.ServiceProvider
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         self.service_logger.info('Executing close-session RPC')
         return self.executor.execute_rpc(provider, ietf_netconf.CloseSessionRpc())
 
-    def commit(self, provider):
-        """ Execute a commit operation to commit the candidate configuration as the device's new
-            current configuration.
+    def commit(self, provider, confirmed=False, confirm_timeout=None, persist=False, persist_id=None):
+        """Execute a commit operation to commit the candidate configuration as the
+           device's new current configuration.
 
-            Args:
-                - provider: An instance of ydk.providers.ServiceProvider
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            confirmed (bool): Perform a confirmed commit operation.
+            confirm_timeout (int): The timeout interval for a confirmed commit.
+            persist (str): Make a confirmed commit persistent. A persistent
+                confirmed commit is not aborted if the NETCONF session
+                terminates. The only way to abort a persistent confirmed commit
+                is to let the timer expire, or to use the <cancel-commit>
+                operation. The value of this parameter is a token that must be
+                given in the 'persist-id' parameter of <commit> or
+                <cancel-commit> operations in order to confirm or cancel the
+                persistent confirmed commit.
+                The token should be a random string.
+            persist_id (str): This parameter is given in order to commit a
+                persistent confirmed commit. The value must be equal to the
+                value given in the 'persist' parameter to the <commit>
+                operation. If it does not match, the operation fails with an
+                'invalid-value' error.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         self.service_logger.info('Executing commit RPC')
-        return self.executor.execute_rpc(provider, ietf_netconf.CommitRpc())
-
-    def commit_confirmed(self, provider, confirm_timeout=None, persist=False, persist_id=None):
-        """ Execute a commit operation to commit the candidate configuration with a confirmed option.
-
-            Args:
-                - provider: An instance of ydk.providers.ServiceProvider
-                - confirm_timeout: The timeout interval for a confirmed commit
-                - persist: This parameter is used to make a confirmed commit persistent. A persistent confirmed commit
-                 is not aborted if the NETCONF session terminates.  The only way to abort a persistent confirmed commit
-                 is to let the timer expire, or to use the <cancel-commit> operation. The value of this parameter is
-                 a token that must be given in the 'persist-id' parameter of <commit> or <cancel-commit> operations
-                 in order to confirm or cancel the persistent confirmed commit.  The token should be a random string
-                - persist_id: This parameter is given in order to commit a persistent confirmed commit. The value must
-                 be equal to the value given in the 'persist' parameter to the <commit> operation. If it does not match,
-                 the operation fails with an 'invalid-value' error
-
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
-
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
-        """
-        self.service_logger.info('Executing commit-confirmed RPC')
         rpc = ietf_netconf.CommitRpc()
         rpc.input.confirm_timeout = confirm_timeout
         rpc.input.persist_id = persist_id
+        if confirmed:
+            rpc.input.confirmed = Empty()
         if persist:
             rpc.input.persist = Empty()
 
         return self.executor.execute_rpc(provider, rpc)
 
     def copy_config(self, provider, target, source, with_defaults_option=None):
-        """ Execute a copy-config operation to create or replace an entire configuration datastore with the
-            contents of another complete configuration datastore.
+        """ Execute a copy-config operation to create or replace an entire
+            configuration datastore with the contents of another complete
+            configuration datastore.
 
-            Args:
-                - target: Particular configuration to copy to
-                - source: Particular configuration to copy from
-                - with_defaults: The explicit defaults processing mode requested
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            target (Datastore | str): Particular configuration to copy to.
+                Valid options are Datastore.candidate, Datastore.running,
+                Datastore.startup and url(str) if the device has such feature
+                advertised in device capability.
+            source (Datastore | str | object): Particular configuration to copy
+                from. Valid options are Datastore.candidate, Datastore.running,
+                Datastore.startup and url(str) if the deivce has such feature
+                advertised in capability. YDK entity object could also be used
+                as a config block for this parameter.
+            with_defaults (WithDefaultsModeEnum): The explicit defaults
+                processing mode requested.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         if None in (target, source):
             self.service_logger.error('Passed in a None arg')
             err_msg = "'target' and 'source' cannot be None"
             raise YPYServiceError(error_msg=err_msg)
 
-        # from pdb import set_trace; set_trace()
         if with_defaults_option is not None and not isinstance(with_defaults_option, ietf_netconf_with_defaults.WithDefaultsModeEnum):
             err_msg = "optional arg 'with_defaults_option' must be of type ietf_netconf_with_defaults.WithDefaultsModeEnum"
             raise YPYServiceError(error_msg=err_msg)
@@ -182,24 +189,28 @@ class NetconfService(Service):
         _validate_datastore_options(target, 'copy-config:target')
         rpc.input.source = _get_rpc_datastore_object(source, rpc.input.source)
         rpc.input.target = _get_rpc_datastore_object(target, rpc.input.target)
-        rpc.input.with_defaults_option = with_defaults_option
+        rpc.input.with_defaults = with_defaults_option
 
         return self.executor.execute_rpc(provider, rpc)
 
     def delete_config(self, provider, target):
-        """ Execute an delete-config operation to delete a configuration datastore.
+        """Execute an delete-config operation to delete a configuration datastore.
 
-            Args:
-                - target: Particular configuration to delete
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            target (Datastore.startup | str): Particular configuration to
+                delete. Valid options are Datastore.startup or url(str).
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         if target is None:
             err_msg = "'target' cannot be None"
@@ -213,44 +224,52 @@ class NetconfService(Service):
         return self.executor.execute_rpc(provider, rpc)
 
     def discard_changes(self, provider):
-        """ Execute a discard-changes operation to revert the candidate configuration to the current
-            running configuration.
+        """Execute a discard-changes operation to revert the candidate
+        configuration to the current running configuration.
 
-            Args:
-                - provider: An instance of ydk.providers.ServiceProvider
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         self.service_logger.info('Executing discard-changes RPC')
         return self.executor.execute_rpc(provider, ietf_netconf.DiscardChangesRpc())
 
     def edit_config(self, provider, target, config, default_operation=None, error_option=None, test_option=None):
-        """ Execute an edit-config operation to load all or part of a specified
-            configuration to the specified target configuration.
+        """Execute an edit-config operation to load all or part of a specified
+           configuration to the specified target configuration.
 
-            Args:
-                - provider: An instance of ydk.providers.ServiceProvider
-                - target: Particular configuration to edit
-                - config: Inline Config content
-                - default_operation: The default operation to use
-                - error_option: The error option to use
-                - test_option: The test option to use
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            target (Datastore): Particular configuration to copy from. Valid
+                options are Datastore.candidate, Datastore.running.
+            config (object): A YDK entity object used as a config block.
+            default_operation (EditConfigRpc.Input.DefaultOperationEnum):
+                Selects the default operation for this edit-config request.
+            error_option (EditConfigRpc.Input.ErrorOptionEnum): Selects the
+                error option for this edit-config request.
+            test_option (EditConfigRpc.Input.TestOptionEnum): Selects the
+                test option for this edit-config request.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         if None in (target, config):
             self.service_logger.error('Passed in a None arg')
@@ -279,22 +298,32 @@ class NetconfService(Service):
         return self.executor.execute_rpc(provider, rpc)
 
     def get_config(self, provider, source, get_filter, with_defaults_option=None):
-        """ Execute a get-config operation to retrieve all or part of a specified configuration.
+        """Execute a get-config operation to retrieve all or part of a
+        specified configuration.
 
-            Args:
-                - get_filter: Subtree or XPath filter to use
-                - source: Particular configuration to retrieve
-                - with_defaults: The explicit defaults processing mode requested
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            source (Datastore): Particular configuration to retrieve. Valid
+                options are Datastore.candidate, Datastore.running,
+                and Datastore.startup.
+            get_filter (object): A YDK entity object used as a subtree filter
+                or XPath filter.
+            with_defaults (WithDefaultsModeEnum): The explicit defaults
+                processing mode requested.
 
-           Returns:
-                 - Copy of the running datastore subset and/or state data that matched the filter criteria (if any).
-                   An empty data container indicates that the request did not produce any results
+        Returns:
+            A YDK entity object represents copy of the running datastore subset
+            and/or state data that matched the filter criteria (if any). An
+            empty data container indicates that the request did not produce
+            any results.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         if source is None:
             err_msg = "'source' cannot be None"
@@ -310,29 +339,36 @@ class NetconfService(Service):
         rpc.input.filter = get_filter
         _validate_datastore_options(source, 'get-config:source')
         rpc.input.source = _get_rpc_datastore_object(source, rpc.input.source)
-        rpc.input.with_defaults_option = with_defaults_option
+        rpc.input.with_defaults = with_defaults_option
 
         payload = self.executor.execute_rpc(provider, rpc)
         return provider.decode(payload_convert(payload), None)
 
     def get(self, provider, get_filter, with_defaults_option=None):
-        """ Execute a get operation to retrieve running configuration and device state information.
+        """Execute a get operation to retrieve running configuration and device
+        state information.
 
-            Args:
-                - get_filter: This parameter specifies the portion of the system configuration and state data to retrieve
-                - with_defaults: The explicit defaults processing mode requested
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            get_filter (object): A YDK entity object specifies the portion of
+                the system configuration and state data to retrieve.
+            with_defaults (WithDefaultsModeEnum): The explicit defaults
+                processing mode requested.
 
-           Returns:
-                 - Copy of the running datastore subset and/or state data that matched the filter criteria (if any).
-                   An empty data container indicates that the request did not produce any results
+        Returns:
+            A YDK entity object represents copy of the running datastore subset
+            and/or state data that matched the filter criteria (if any). An
+            empty data container indicates that the request did not produce
+            any results
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
-
         if with_defaults_option is not None and not isinstance(with_defaults_option, ietf_netconf_with_defaults.WithDefaultsModeEnum):
             err_msg = "optional arg 'with_defaults_option' must be of type ietf_netconf_with_defaults.WithDefaultsModeEnum"
             raise YPYServiceError(error_msg=err_msg)
@@ -340,26 +376,29 @@ class NetconfService(Service):
 
         rpc = ietf_netconf.GetRpc()
         rpc.input.filter = get_filter
-        rpc.input.with_defaults_option = with_defaults_option
+        rpc.input.with_defaults = with_defaults_option
 
         payload = self.executor.execute_rpc(provider, rpc)
         return provider.decode(payload_convert(payload), None)
 
     def kill_session(self, provider, session_id):
-        """ Execute a kill-session operation to force the termination of a NETCONF session.
+        """Execute a kill-session operation to force the termination of a
+        NETCONF session.
 
-            Args:
-                - session_id: Particular session to kill
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            session_id (int): Particular session to kill.
 
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
-
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         self.service_logger.info('Executing kill-session RPC')
         rpc = ietf_netconf.KillSessionRpc()
@@ -368,20 +407,25 @@ class NetconfService(Service):
         return self.executor.execute_rpc(provider, rpc)
 
     def lock(self, provider, target):
-        """ Execute a lock operation to allow the client to lock the configuration
-            system of a device.
+        """Execute a lock operation to allow the client to lock the
+        configuration system of a device.
 
-            Args:
-                - target: Particular configuration to lock
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            target (Datastore): Particular configuration to lock. Valid options
+            are Datastore.candidate, Datastore.running, and Datastore.startup
+            if the device has such feature advertised.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         if target is None:
             err_msg = "'target' cannot be None"
@@ -395,20 +439,25 @@ class NetconfService(Service):
         return self.executor.execute_rpc(provider, rpc)
 
     def unlock(self, provider, target):
-        """ Execute an unlock operation to  release a configuration lock,
-            previously obtained with the 'lock' operation.
+        """Execute an unlock operation to  release a configuration lock,
+        previously obtained with the 'lock' operation.
 
-            Args:
-                - target: Particular configuration to unlock
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            target (Datastore): Particular configuration to unlock. Valid
+            options are Datastore.candidate, Datastore.running, and
+            Datastore.startup if the device has such feature advertised.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
         if target is None:
             err_msg = "'target' cannot be None"
@@ -421,24 +470,31 @@ class NetconfService(Service):
 
         return self.executor.execute_rpc(provider, rpc)
 
-    def validate(self, provider, source=None, config=None):
-        """ Execute a validate operation to validate the contents of the specified configuration.
+    def validate(self, provider, source=None):
+        """Execute a validate operation to validate the contents of the
+        specified configuration.
 
-            Args:
-                - source: Particular configuration to validate
-                - with_defaults: The explicit defaults processing mode requested
+        Args:
+            provider (ydk.providers.ServiceProvider): A provider instance.
+            source (Datastore | str | object): Particular configuration to
+                validate. Valid options are Datastore.candidate,
+                Datastore.running, Datastore.startup and url(str) if the deivce
+                has such feature advertised in device capability. YDK entity
+                object could also be used as a config block for this parameter.
 
-           Returns:
-                 - ok reply if operation succeeds else, raises an exception
+        Returns:
+            An ok reply string if operation succeeds.
 
-           Raises:
-              `YPYModelError <ydk.errors.html#ydk.errors.YPYModelError>`_ if validation error occurs.
-              `YPYServiceError <ydk.errors.html#ydk.errors.YPYServiceError>`_ if other error has occurred. Possible errors could be
-                  - a server side error
-                  - if there isn't enough information in the entity to prepare the message (missing keys for example)
+        Raises:
+            YPYModelError: If validation error occurs.
+            YPYServiceError: If other error has occurred.
+                Possible errors could be:
+                    - A server side error
+                    - If there isn't enough information in the entity to
+                      prepare the message (missing keys for example).
         """
-        if source is None and config is None:
-            err_msg = "'source' and 'config' cannot be None"
+        if source is None:
+            err_msg = "'source' cannot be None"
             raise YPYServiceError(error_msg=err_msg)
         self.service_logger.info('Executing validate RPC')
 
@@ -446,8 +502,6 @@ class NetconfService(Service):
         if source is not None:
             _validate_datastore_options(source, 'validate:source')
             rpc.input.source = _get_rpc_datastore_object(source, rpc.input.source)
-        if config is not None:
-            rpc.input.source.config = config
 
         return self.executor.execute_rpc(provider, rpc)
 
@@ -465,8 +519,10 @@ def _get_rpc_datastore_object(datastore, rpc_datastore_type):
     elif datastore == Datastore.startup:
         rpc_datastore_type.startup = Empty()
         return rpc_datastore_type
-    else:
-        raise YPYModelError('Invalid datastore specified')
+    elif isinstance(datastore, object):
+        rpc_datastore_type.config = datastore
+        return rpc_datastore_type
+    raise YPYModelError('Invalid datastore specified')
 
 
 def payload_convert(payload):
@@ -482,7 +538,7 @@ def _validate_datastore_options(datastore, option):
     if option == 'copy-config:target':
         res = isinstance(datastore, (str, Datastore))
     elif option == 'copy-config:source':
-        res = isinstance(datastore, (str, Datastore))
+        res = isinstance(datastore, (str, object, Datastore))
     elif option == 'delete-config:target':
         res = isinstance(datastore, str) or datastore == Datastore.startup
     elif option == 'edit-config:target':
@@ -494,7 +550,7 @@ def _validate_datastore_options(datastore, option):
     elif option == 'unlock:target':
         res = isinstance(datastore, Datastore)
     elif option == 'validate:source':
-        res = isinstance(datastore, (str, Datastore))
+        res = isinstance(datastore, (str, object, Datastore))
 
     if not res:
         err_msg = _get_datastore_errmsg(option, datastore)
@@ -502,10 +558,8 @@ def _validate_datastore_options(datastore, option):
 
 
 def _get_datastore_errmsg(option, datastore):
-    if isinstance(datastore, Datastore):
-        pass
-    elif isinstance(datastore, str):
+    if isinstance(datastore, str):
         datastore = 'url'
     if ':' in option:
         option = option[:option.find(':')]
-    return "%s datastore is not supported by Netconf %s operation" % (datastore, option)
+    return ("%s datastore is not supported by Netconf %s operation" % (datastore, option))


### PR DESCRIPTION
- Updated documentation and docstring to NetconfService (#239)
- copy-config/validate now can accept YDK entity as source (#248)
- merged commit/commit_confirmed into one method (#247)
- make copy-config/validate consistent with RFC 6241 (#235)