### PR TITLE
Fixed bug introduced in commit: fcfe591

### DIFF
--- a/profiles/test/ydktest-cpp.json
+++ b/profiles/test/ydktest-cpp.json
@@ -35,7 +35,24 @@
             "yang/ietf/ietf-inet-types@2013-07-15.yang",
             "yang/ietf/ietf-yang-types@2013-07-15.yang",
             "yang/ydktest/oc-pattern@2015-11-17.yang"
-        ]
+        ],
+
+    "git":
+    [
+        {
+            "url": "https://github.com/YangModels/yang.git",
+            "commits":
+            [
+                {
+                    "commitid": "a5e3d7f27e0e846cac6b6357ff460b8facc810a8",
+                    "file":
+                    [
+                        "standard/ietf/RFC/iana-if-type.yang"
+                    ]
+                }
+            ]
+        }
+    ]
     }
 }
 

--- a/ydkgen/printer/language_bindings_printer.py
+++ b/ydkgen/printer/language_bindings_printer.py
@@ -109,12 +109,12 @@ class LanguageBindingsPrinter(object):
         identity_tuples = self._get_identity_tuples()
         for (child_identity, base_identities) in identity_tuples:
             for base_identity in base_identities:
-                if base_identity in identity_subclasses:
-                    existing_child_identities = identity_subclasses[base_identity]
+                if id(base_identity) in identity_subclasses:
+                    existing_child_identities = identity_subclasses[id(base_identity)]
                     existing_child_identities.append(child_identity)
-                    identity_subclasses[base_identity] = existing_child_identities
+                    identity_subclasses[id(base_identity)] = existing_child_identities
                 else:
-                    identity_subclasses[base_identity] = [child_identity]
+                    identity_subclasses[id(base_identity)] = [child_identity]
         return identity_subclasses
 
     def _get_identity_tuples(self):
@@ -134,7 +134,7 @@ class LanguageBindingsPrinter(object):
         return identity_subclasses
 
     def _filter_bundle_pkgs(self):
-        bundle_pkgs = set()
+        bundle_pkgs = {}
         for pkg in self.packages:
             if pkg.bundle_name == self.bundle_name:
                 # we have multiple models being augmented.
@@ -145,7 +145,7 @@ class LanguageBindingsPrinter(object):
                             # augmenting models in existing bundle.
                             aug_pkg.aug_bundle_name = aug_pkg.bundle_name
                             aug_pkg.bundle_name = self.bundle_name
-                            bundle_pkgs.add(aug_pkg)
-                bundle_pkgs.add(pkg)
+                            bundle_pkgs[id(aug_pkg)] = aug_pkg
+                bundle_pkgs[id(pkg)] = pkg
 
-        return list(bundle_pkgs)
+        return list(bundle_pkgs.values())

--- a/ydkgen/printer/python/module_printer.py
+++ b/ydkgen/printer/python/module_printer.py
@@ -64,7 +64,7 @@ class ModulePrinter(FilePrinter):
         imports_to_print = set()
 
         for imported_type in package.imported_types():
-            if all((imported_type in self.identity_subclasses,
+            if all((id(imported_type) in self.identity_subclasses,
                     self._is_derived_identity(package, imported_type))):
                 imported_stmt = 'from %s import %s' % (
                     imported_type.get_py_mod_name(),


### PR DESCRIPTION
- Revert changes `identity_subclasses`, use object id as dictionary key for `identity_subclasses`.
- Tested with models used in #216.