### PR TITLE
Use unique_ptr in ydk path API schema nodes to avoid memory leaks

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -192,7 +192,7 @@ def create_shared_libraries(output_directory):
     except subprocess.CalledProcessError as e:
         print('\nERROR: Failed to create shared library!\n')
         sys.exit(e.returncode)
-    print('\nSuccessfully created shared libraries at {0}.\nTo install, run "[sudo] make install" from {0}'.format(output_directory, cmake_build_dir))
+    print('\nSuccessfully created shared libraries at {0}.\nTo install, run "[sudo] make install" from {1}'.format(output_directory, cmake_build_dir))
     print('\n=================================================')
     print('Successfully generated C++ YDK at %s' % (cpp_sdk_root,))
     print('Please read %s/README.md for information on how to use YDK\n' % (

--- a/sdk/cpp/samples/bgp_create.cpp
+++ b/sdk/cpp/samples/bgp_create.cpp
@@ -45,7 +45,6 @@ void config_bgp(openconfig_bgp::Bgp* bgp)
 	auto neighbor = make_unique<openconfig_bgp::Bgp::Neighbors::Neighbor>();
 	neighbor->neighbor_address = "6.7.8.9";
 	neighbor->config->neighbor_address = "6.7.8.9";
-//	neighbor->config->enabled = true;
 	neighbor->config->peer_as = 65001;
 	neighbor->config->local_as = 65001;
 	neighbor->config->peer_group = "IBGP";

--- a/sdk/cpp/samples/isis_xr_create.cpp
+++ b/sdk/cpp/samples/isis_xr_create.cpp
@@ -48,6 +48,8 @@ void config_isis(Isis* isis)
 	auto af = make_unique<Isis::Instances::Instance::Afs::Af>();
 	af->af_name = IsisAddressFamilyEnum::ipv4;
 	af->saf_name = IsisSubAddressFamilyEnum::unicast;
+	af->af_data = make_unique<Isis::Instances::Instance::Afs::Af::AfData>(); // instantiate the presence node
+	af->af_data->parent = af.get(); // set the parent
 	auto metric_style = make_unique<Isis::Instances::Instance::Afs::Af::AfData::MetricStyles::MetricStyle>();
 	metric_style->style = IsisMetricStyleEnum::new_metric_style;
 	metric_style->level = IsisInternalLevelEnum::not_set;

--- a/sdk/cpp/tests/test_netconf_client.cpp
+++ b/sdk/cpp/tests/test_netconf_client.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(xr)
 
 
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(Create)
 	int result = client.connect();
 	BOOST_REQUIRE(result == OK);
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(EditgetConfig)
 	 "</rpc>");
 	BOOST_REQUIRE(NULL != strstr(reply.c_str(), "<ok/>"));
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(Validate)
 
 	BOOST_REQUIRE(NULL != strstr(reply.c_str(), "<ok/>"));
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(LockUnlock)
 
 	BOOST_REQUIRE(NULL != strstr(reply.c_str(), "<rpc-error>"));
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -204,24 +204,8 @@ BOOST_AUTO_TEST_CASE(RpcError)
 	 "</rpc>");
 	BOOST_REQUIRE(NULL != strstr(reply.c_str(), "<rpc-error>"));
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
-}
-
-BOOST_AUTO_TEST_CASE(DeviceNotConnectedClose)
-{
-	NetconfClient client{ "admin", "admin", "127.0.0.1", 12022, 0};
-	int result = 1;
-	try
-	{
-		result = client.close();
-	}
-	catch (YDKException & e)
-	{
-		BOOST_REQUIRE(e.err_msg=="Could not close session. Not connected to 127.0.0.1");
-	}
-
-
 }
 
 BOOST_AUTO_TEST_CASE(DeviceNotConnectedExecute)
@@ -273,7 +257,7 @@ BOOST_AUTO_TEST_CASE(RpcInvalid)
 		BOOST_REQUIRE(e.err_msg=="Could not build payload");
 	}
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -297,7 +281,7 @@ BOOST_AUTO_TEST_CASE(WrongXml)
 		BOOST_REQUIRE(e.err_msg=="Could not build payload");
 	}
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -322,7 +306,7 @@ BOOST_AUTO_TEST_CASE(CorrectXmlWrongRpc)
 	}
 
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -344,7 +328,7 @@ BOOST_AUTO_TEST_CASE(EmptyRpc)
 		BOOST_REQUIRE(e.err_msg=="Could not build payload");
 	}
 
-	result = client.close();
+
 	BOOST_REQUIRE(result == OK);
 }
 
@@ -371,9 +355,5 @@ BOOST_AUTO_TEST_CASE(MultipleClients)
 		 && client11.connect() && client12.connect() && client13.connect() && client14.connect() && client15.connect();
 	BOOST_REQUIRE(result == 0);
 
-	result = client1.close() && client2.close() && client3.close() && client4.close() && client5.close()
-			 && client6.close() && client7.close() && client8.close() && client9.close() && client10.close()
-			 && client11.close() && client12.close() && client13.close() && client14.close() && client15.close();
-	BOOST_REQUIRE(result == 0);
 }
 

--- a/sdk/cpp/ydk/docsgen/developer_guide.rst
+++ b/sdk/cpp/ydk/docsgen/developer_guide.rst
@@ -5,4 +5,5 @@ Developer Guide
    :maxdepth: 2
 
    introduction.rst
+   guides/presence_class.rst
    guides/howto.rst

--- a/sdk/cpp/ydk/docsgen/guides/presence_class.rst
+++ b/sdk/cpp/ydk/docsgen/guides/presence_class.rst
@@ -1,0 +1,23 @@
+.. _presence-class:
+
+Presence Classes
+==================
+According to `RFC 6020 <https://tools.ietf.org/html/rfc6020#section-7.5.1>`_, YANG supports two styles of containers, one for organizing hierarchy, another for representing configuration data. The latter type of containers are called presence containers. For instance, the existence of a presence container ``ssh`` may be used to indicate whether ssh login is enabled or not.
+
+Let us consider a class named ``Conditions``, with two members ``match_prefix_set`` (which is a presence node) and ``match_neighbor_set`` (which is a non-presence node).
+
+.. code-block:: cpp
+
+    Conditions::Conditions()
+      :     match_prefix_set(nullptr),
+            match_neighbor_set(std::make_unique<openconfig_bgp::Bgp::Conditions::MatchNeighborSet>())
+
+When instantiating the ``Conditions`` class, the child ``match_prefix_set`` will be initially assigned to a null pointer. So, in order to configure the match prefix set, the user has to initialize the  ``match_prefix_set`` as shown below:
+
+
+.. code-block:: cpp
+
+    auto conditions = std::make_unique<openconfig_bgp::Bgp::Conditions>();
+    conditions->match_prefix_set = std::make_unique<openconfig_bgp::Bgp::Conditions::MatchPrefixSet>(); // instantiate the presence node
+    conditions->match_prefix_set = conditions.get(); //set the parent
+

--- a/sdk/cpp/ydk/samples/bgp.cpp
+++ b/sdk/cpp/ydk/samples/bgp.cpp
@@ -14,11 +14,11 @@
 #include "../src/netconf_provider.hpp"
 
 
-void print_paths(ydk::path::SchemaNode* sn)
+void print_paths(ydk::path::SchemaNode & sn)
 {
-    std::cout << sn->path() << std::endl;
-    for(auto p : sn->children())
-        print_paths(p);
+    std::cout << sn.path() << std::endl;
+    for(auto const& p : sn.children())
+        print_paths(*p);
 }
 
 void test_bgp_create()
@@ -28,7 +28,7 @@ void test_bgp_create()
     ydk::NetconfServiceProvider sp{&repo,"127.0.0.1", "admin", "admin",  2022};
 
     ydk::path::RootSchemaNode* schema = sp.get_root_schema();
-    print_paths(schema);
+    print_paths(*schema);
 
     auto bgp = schema->create("openconfig-bgp:bgp", "");
 

--- a/sdk/cpp/ydk/src/netconf_client.cpp
+++ b/sdk/cpp/ydk/src/netconf_client.cpp
@@ -103,12 +103,9 @@ string NetconfClient::execute_payload(const string & payload)
 	return reply_payload;
 }
 
-int NetconfClient::close()
+NetconfClient::~NetconfClient()
 {
-	perform_session_check("Could not close session. Not connected to " + hostname);
-
 	nc_session_free(session);
-	return EXIT_SUCCESS;
 }
 
 nc_rpc* NetconfClient::build_rpc_request(const string & payload)

--- a/sdk/cpp/ydk/src/netconf_client.hpp
+++ b/sdk/cpp/ydk/src/netconf_client.hpp
@@ -57,9 +57,10 @@ public:
 	NetconfClient(std::string  username, std::string  password,
 			std::string  server_ip, int port, int verbosity);
 
+	~NetconfClient();
+
 	int connect();
 	std::string execute_payload(const std::string & payload);
-	int close();
 	std::vector<std::string> get_capabilities();
 	std::string get_hostname_port();
 

--- a/sdk/cpp/ydk/src/netconf_provider.hpp
+++ b/sdk/cpp/ydk/src/netconf_provider.hpp
@@ -39,9 +39,9 @@ public:
                                int port);
         ~NetconfServiceProvider();
 
-        virtual path::RootSchemaNode* get_root_schema() const;
+        path::RootSchemaNode* get_root_schema() const;
 
-        virtual path::DataNode* invoke(path::Rpc* rpc) const;
+        path::DataNode* invoke(path::Rpc* rpc) const;
 
         static const char* CANDIDATE;
         static const char* MODULE_NAME;

--- a/sdk/cpp/ydk/src/path/path_private.hpp
+++ b/sdk/cpp/ydk/src/path/path_private.hpp
@@ -69,7 +69,7 @@ namespace ydk {
 
             const SchemaNode* parent() const noexcept;
 
-            std::vector<SchemaNode*> children() const;
+            const std::vector<std::unique_ptr<SchemaNode>> & children() const;
 
 
             const SchemaNode* root() const noexcept;
@@ -78,13 +78,13 @@ namespace ydk {
 
             std::vector<Statement> keys() const;
 
-            SchemaValueType* type() const;
+            SchemaValueType & type() const;
 
             const SchemaNode* m_parent;
             struct lys_node* m_node;
-            std::vector<SchemaNode*> m_children;
+            std::vector<std::unique_ptr<SchemaNode>> m_children;
 
-            SchemaValueType* m_type;
+            std::unique_ptr<SchemaValueType> m_type;
 
 
         };
@@ -97,7 +97,7 @@ namespace ydk {
 
             std::vector<SchemaNode*> find(const std::string& path) const;
 
-            std::vector<SchemaNode*> children() const;
+            const std::vector<std::unique_ptr<SchemaNode>> & children() const;
             DataNode* create(const std::string& path) const;
             DataNode* create(const std::string& path, const std::string& value) const;
 
@@ -107,17 +107,11 @@ namespace ydk {
 
 
             Rpc* rpc(const std::string& path) const;
-
-
-
-            SchemaValueType* type() const
-            {
-                return nullptr;
-            }
+            SchemaValueType & type() const;
 
 
             struct ly_ctx* m_ctx;
-            std::vector<SchemaNode*> m_children;
+            std::vector<std::unique_ptr<SchemaNode>> m_children;
 
         };
 
@@ -238,9 +232,9 @@ namespace ydk {
 
         };
 
-        SchemaValueType* create_schema_value_type(struct lys_node_leaf* leaf,
+        std::unique_ptr<SchemaValueType> create_schema_value_type(struct lys_node_leaf* leaf,
         												  struct lys_type* type);
-        SchemaValueType* create_schema_value_type(struct lys_node_leaf* leaf);
+        std::unique_ptr<SchemaValueType> create_schema_value_type(struct lys_node_leaf* leaf);
     }
 
 

--- a/sdk/cpp/ydk/src/path/root_data_node.cpp
+++ b/sdk/cpp/ydk/src/path/root_data_node.cpp
@@ -185,17 +185,20 @@ ydk::path::RootDataImpl::find(const std::string& path) const
 {
     std::vector<DataNode*> results;
 
-    if(m_node == nullptr) {
+    if(m_node == nullptr)
+    {
         return results;
     }
 
     std::string schema_path{ this->path() };
-    if(schema_path.size()!= 1){
+    if(schema_path.size()!= 1)
+    {
         schema_path+="/";
     }
 
     auto s = schema()->statement();
-    if(s.keyword == "rpc") {
+    if(s.keyword == "rpc")
+    {
         schema_path+="input/";
     }
 
@@ -204,7 +207,8 @@ ydk::path::RootDataImpl::find(const std::string& path) const
     BOOST_LOG_TRIVIAL(trace) << "Looking for schema nodes path in root: '"<<schema_path<<"'";
     const struct lys_node* found_snode = ly_ctx_get_node(m_node->schema->module->ctx, nullptr, schema_path.c_str());
 
-    if(found_snode) {
+    if(found_snode)
+    {
         struct ly_set* result_set = lyd_find_instance(m_node, found_snode);
         if( result_set )
         {

--- a/sdk/cpp/ydk/src/path/root_schema_node.cpp
+++ b/sdk/cpp/ydk/src/path/root_schema_node.cpp
@@ -76,7 +76,7 @@ ydk::path::RootSchemaNodeImpl::RootSchemaNodeImpl(struct ly_ctx* ctx) : m_ctx{ct
     while( auto p = ly_ctx_get_module_iter(ctx, &idx)) {
         const struct lys_node *last = nullptr;
         while( auto q = lys_getnext(last, nullptr, p, 0)) {
-            m_children.push_back(new SchemaNodeImpl{this, const_cast<struct lys_node*>(q)});
+            m_children.push_back(std::make_unique<SchemaNodeImpl>(this, const_cast<struct lys_node*>(q)));
             last = q;
         }
     }
@@ -122,7 +122,7 @@ ydk::path::RootSchemaNodeImpl::find(const std::string& path) const
     return ret;
 }
 
-std::vector<ydk::path::SchemaNode*>
+const std::vector<std::unique_ptr<ydk::path::SchemaNode>> &
 ydk::path::RootSchemaNodeImpl::children() const
 {
     return m_children;
@@ -190,4 +190,11 @@ ydk::path::RootSchemaNodeImpl::rpc(const std::string& path) const
     }
     return new RpcImpl{sn, m_ctx};
 
+}
+
+ydk::path::SchemaValueType &
+ydk::path::RootSchemaNodeImpl::type() const
+{
+	auto ignored = std::make_unique<SchemaValueBoolType>();
+    return *ignored;
 }

--- a/sdk/cpp/ydk/src/path/schema_value_type.cpp
+++ b/sdk/cpp/ydk/src/path/schema_value_type.cpp
@@ -198,9 +198,7 @@ ydk::path::SchemaValueEnumerationType::validate(const std::string& value) const
 
 ydk::path::SchemaValueIdentityType::~SchemaValueIdentityType()
 {
-    for(auto identity : derived) {
-        delete identity;
-    }
+
 }
 
 ydk::path::DiagnosticNode<std::string, ydk::path::ValidationError>
@@ -224,7 +222,7 @@ ydk::path::SchemaValueIdentityType::validate(const std::string& value) const
             return diag;
     }
 
-    for(auto ident : derived) {
+    for(auto const& ident : derived) {
         if(!ident->validate(value).has_errors()){
             return diag;
         }
@@ -327,9 +325,7 @@ ydk::path::SchemaValueStringType::validate(const std::string& value) const
 
 ydk::path::SchemaValueUnionType::~SchemaValueUnionType()
 {
-    for(auto type : types) {
-        delete type;
-    }
+
 }
 
 
@@ -337,7 +333,7 @@ ydk::path::DiagnosticNode<std::string, ydk::path::ValidationError>
 ydk::path::SchemaValueUnionType::validate(const std::string& value) const
 {
 
-    for(auto type : types){
+    for(auto const& type : types){
         auto diag = type->validate(value);
         if(!diag.has_errors()){
             return diag;

--- a/sdk/cpp/ydk/src/path_api.hpp
+++ b/sdk/cpp/ydk/src/path_api.hpp
@@ -841,7 +841,7 @@ namespace ydk {
 
 
             /// derived identities
-            std::vector<SchemaValueIdentityType*> derived;
+            std::vector<std::unique_ptr<SchemaValueIdentityType>> derived;
 
         };
 
@@ -939,7 +939,7 @@ namespace ydk {
             DiagnosticNode<std::string, ValidationError> validate(const std::string& value) const;
 
             /// types defined
-            std::vector<SchemaValueType*> types;
+            std::vector<std::unique_ptr<SchemaValueType>> types;
         };
 
         ///
@@ -1016,7 +1016,7 @@ namespace ydk {
             ///
             /// Returns the children of this SchemaNode.
             ///@return the children of this node.
-            virtual std::vector<SchemaNode*> children() const = 0;
+            virtual const std::vector<std::unique_ptr<SchemaNode>> & children() const = 0;
 
             ///
             /// @brief get the root of NodeTree this node is part of
@@ -1053,7 +1053,7 @@ namespace ydk {
             /// @return ptr to SchemaValueType or nullptr. User should not free this pointer
             /// it is contained within the SchemaNode so destroying the SchemaNode.
             ///
-            virtual SchemaValueType* type() const = 0;
+            virtual SchemaValueType & type() const = 0;
 
         };
 
@@ -1100,7 +1100,7 @@ namespace ydk {
             ///
             /// Returns the children of this SchemaNode.
             ///@return the children of this node.
-            virtual std::vector<SchemaNode*> children() const = 0;
+            virtual const std::vector<std::unique_ptr<SchemaNode>> & children() const = 0;
 
             ///
             /// @brief get the root of NodeTree this node is part of

--- a/sdk/cpp/ydk/src/validation_service.cpp
+++ b/sdk/cpp/ydk/src/validation_service.cpp
@@ -64,29 +64,25 @@ validate_attributes(const EntityPath& entity_path, const ydk::path::SchemaNode& 
         if(value_path.second.empty())
             continue;
         auto leaf_schema_node_list = schema_node.find(value_path.first);
-        if(leaf_schema_node_list.empty()) {
+        if(leaf_schema_node_list.empty())
+        {
             //the leaf is invalid or not present in the schema
             ydk::path::DiagnosticNode<std::string, ydk::path::ValidationError> attr{};
             attr.source = value_path.first;
             attr.errors.push_back(ydk::path::ValidationError::SCHEMA_NOT_FOUND);
             diagnostic.attrs.push_back(std::move(attr));
-        } else {
+        }
+        else
+        {
             ydk::path::SchemaNode* leaf_schema_node = leaf_schema_node_list[0];
             //now test to see if the value is correct
-            ydk::path::SchemaValueType* type = leaf_schema_node->type();
-
-            if(type == nullptr) {
-                BOOST_LOG_TRIVIAL(error) << "Cannot derive type for leaf " << leaf_schema_node->statement().arg;
-                BOOST_THROW_EXCEPTION(YDKIllegalStateException{"Cannot derive type for "});
-            } else {
-                auto attr = type->validate(value_path.second);
-                if(attr.has_errors()){
-                    attr.source = value_path.first;
-                    diagnostic.attrs.push_back(std::move(attr));
-                }
-
-            }
-
+            ydk::path::SchemaValueType & type = leaf_schema_node->type();
+	    auto attr = type.validate(value_path.second);
+	    if(attr.has_errors())
+            {
+		attr.source = value_path.first;
+		diagnostic.attrs.push_back(std::move(attr));
+	    }
         }
     }
 

--- a/sdk/cpp/ydk/src/value.cpp
+++ b/sdk/cpp/ydk/src/value.cpp
@@ -107,7 +107,6 @@ const std::string  Value::get() const
 
 std::pair<std::string, std::string> Value::get_name_value() const
 {
-	BOOST_LOG_TRIVIAL(trace) <<name<<" : "<<get();
 	return {name, get()};
 }
 

--- a/ydkgen/printer/cpp/class_has_data_printer.py
+++ b/ydkgen/printer/cpp/class_has_data_printer.py
@@ -29,7 +29,7 @@ class ClassHasDataPrinter(object):
         leafs = [prop for prop in ls if not prop.is_many]
         chs = [prop for prop in children if not prop.is_many]
         conditions = [ '%s.is_set' % (p.name) for p in leafs ]
-        conditions.extend(['%s->has_data()' % (p.name) for p in chs])
+        conditions.extend([('(%s !=  nullptr && %s->has_data())\n' % (p.name, p.name)) for p in chs])
         self.ctx.writeln('bool %s::has_data() const' % clazz.qualified_cpp_name())
         self.ctx.writeln('{')
         self.ctx.lvl_inc()

--- a/ydkgen/printer/meta_data_util.py
+++ b/ydkgen/printer/meta_data_util.py
@@ -55,6 +55,10 @@ class MetaInfoData:
         self.min_elements = prop.min_elements
         self.target_of_leafref = ''
         self.mandatory = False
+        self.is_presence = False
+        self.units = ''
+        self.default_value = ''
+        self.status = ''
 
 
 def get_class_docstring(clazz, language, identity_subclasses=None):
@@ -63,6 +67,7 @@ def get_class_docstring(clazz, language, identity_subclasses=None):
         class_description = clazz.comment
 
     properties_description = []
+
     for prop in clazz.properties():
         prop_comment = ''
         if prop.comment is not None:
@@ -123,6 +128,14 @@ def get_type_doc(meta_info_data, type_depth):
             properties_description.append('\t**refers to**\: %s\n\n' % (meta_info_data.target_of_leafref))
         if meta_info_data.mandatory:
             properties_description.append('\t**mandatory**\: True\n\n')
+        if meta_info_data.is_presence:
+            properties_description.append('\t**presence node**\: True\n\n')
+        if len(meta_info_data.units) > 0:
+            properties_description.append('\t**units**\: %s\n\n' % meta_info_data.units)
+        if len(meta_info_data.default_value) > 0:
+            properties_description.append('\t**default value**\: %s\n\n' % meta_info_data.default_value)
+        if len(meta_info_data.status) > 0:
+            properties_description.append('\t**status**\: %s\n\n' % meta_info_data.status)
 
     return properties_description
 
@@ -197,9 +210,21 @@ def get_meta_info_data(prop, property_type, type_stmt, language, identity_subcla
     if mandatory is not None and mandatory.arg == 'true':
         meta_info_data.mandatory = True
 
-    mandatory = prop.stmt.search_one('mandatory')
-    if mandatory is not None and mandatory.arg == 'true':
-        meta_info_data.mandatory = True
+    presence = prop.stmt.search_one('presence')
+    if presence is not None:
+        meta_info_data.is_presence = True
+
+    units = prop.stmt.search_one('units')
+    if units is not None:
+        meta_info_data.units = units.arg
+
+    status = prop.stmt.search_one('status')
+    if status is not None:
+        meta_info_data.status = status.arg
+
+    default_value = prop.stmt.search_one('default')
+    if default_value is not None:
+        meta_info_data.default_value = default_value.arg
 
     if isinstance(property_type, Class):
         meta_info_data.pmodule_name = "'%s'" % property_type.get_py_mod_name()


### PR DESCRIPTION
 * Make session close part of NetconfClient destructor
 * Fix generate.py message after cpp gen
 * For presence containers, init to nullptr
 * In has_data function, check children for nullptr
 * Print type and other info as comments in generated c++ API