### PR TITLE
Fix requirements file name on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It is recommended to install a python distribution like [PythonXY](https://pytho
 ```
 $ git clone https://github.com/CiscoDevNet/ydk-gen.git
 $ cd ydk-gen
-$ pip install -r requirements
+$ pip install -r requirements.txt
 ```
 
 ## Usage


### PR DESCRIPTION
The ".txt" extension of requirements file was missing in README.md