### PR TITLE
Fix issue with circular import for C++ bindings and other fixes

### DIFF
--- a/ydkgen/builder/_api_model_builder.py
+++ b/ydkgen/builder/_api_model_builder.py
@@ -169,6 +169,11 @@ class ApiModelBuilder(object):
         prop = Property(self.iskeyword)
         stmt.i_property = prop
         prop.stmt = stmt
+
+        for element in parent_element.owned_elements:
+            if element.name == prop.name:
+                prop.name = prop.name + '_'
+
         parent_element.owned_elements.append(prop)
         prop.owner = parent_element
         # for inlined enum types where leaf { type enumeration {

--- a/ydkgen/printer/cpp/class_members_printer.py
+++ b/ydkgen/printer/cpp/class_members_printer.py
@@ -170,21 +170,8 @@ class ClassMembersPrinter(object):
     def _print_class_enums_forward_declarations(self, clazz):
         self.ctx.bline()
         self.ctx.lvl_inc()
-        for prop in clazz.properties():
-            if isinstance(prop.property_type, Enum):
-                self.ctx.writeln('class %s;' % prop.property_type.name)
-            elif isinstance(prop.property_type, UnionTypeSpec):
-                for enum_name in self._get_union_contained_enums(prop.property_type):
-                    self.ctx.writeln('class %s;' % enum_name)
+        for child in clazz.owned_elements:
+            if isinstance(child, Enum):
+                self.ctx.writeln('class %s;' % child.name)
         self.ctx.lvl_dec()
         self.ctx.bline()
-
-    def _get_union_contained_enums(self, union_type):
-        contained_enums = set()
-        for contained_type_stmt in union_type.types:
-            contained_property_type = TypesExtractor().get_property_type(contained_type_stmt)
-            if isinstance(contained_property_type, Enum):
-                contained_enums.add(contained_property_type.name)
-            elif isinstance(contained_property_type, UnionTypeSpec):
-                contained_enums.update(self._get_union_contained_enums(contained_property_type))
-        return contained_enums

--- a/ydkgen/printer/cpp/cpp_bindings_printer.py
+++ b/ydkgen/printer/cpp/cpp_bindings_printer.py
@@ -62,7 +62,7 @@ class CppBindingsPrinter(LanguageBindingsPrinter):
     def _print_header_file(self, package, path):
         self.print_file(get_header_file_name(path, package),
                         emit_header,
-                        _EmitArgs(self.ypy_ctx, package, self.sort_clazz))
+                        _EmitArgs(self.ypy_ctx, package, (self.sort_clazz, self.identity_subclasses)))
 
     def _print_source_file(self, package, path):
         self.print_file(get_source_file_name(path, package),
@@ -119,8 +119,8 @@ def get_cpp_doc_file_name(path, named_element):
     return '%s/%s.rst' % (path, get_rst_file_name(named_element))
 
 
-def emit_header(ctx, package, sort_clazz):
-    HeaderPrinter(ctx, sort_clazz).print_output(package)
+def emit_header(ctx, package, extra_args):
+    HeaderPrinter(ctx, extra_args[0], extra_args[1]).print_output(package)
 
 
 def emit_source(ctx, package, sort_clazz):

--- a/ydkgen/printer/file_printer.py
+++ b/ydkgen/printer/file_printer.py
@@ -21,6 +21,7 @@
 
 """
 import abc
+from ydkgen.api_model import Class
 
 
 class _Stack:
@@ -73,3 +74,11 @@ class FilePrinter(object):
 
     def print_trailer(self, packages):
         pass
+
+    def is_derived_identity(self, package, identity):
+        for ne in package.owned_elements:
+            if isinstance(ne, Class) and ne.is_identity():
+                for ext in ne.extends:
+                    if ext == identity:
+                        return True
+        return False

--- a/ydkgen/printer/python/module_printer.py
+++ b/ydkgen/printer/python/module_printer.py
@@ -65,7 +65,7 @@ class ModulePrinter(FilePrinter):
 
         for imported_type in package.imported_types():
             if all((id(imported_type) in self.identity_subclasses,
-                    self._is_derived_identity(package, imported_type))):
+                    self.is_derived_identity(package, imported_type))):
                 imported_stmt = 'from %s import %s' % (
                     imported_type.get_py_mod_name(),
                     imported_type.qn().split('.')[0])
@@ -75,14 +75,6 @@ class ModulePrinter(FilePrinter):
             self.ctx.writeln(imported_stmt)
 
         self.ctx.bline()
-
-    def _is_derived_identity(self, package, identity):
-        for ne in package.owned_elements:
-            if isinstance(ne, Class) and ne.is_identity():
-                for ext in ne.extends:
-                    if ext == identity:
-                        return True
-        return False
 
     def _print_static_imports(self):
         self.ctx.str('''


### PR DESCRIPTION
 * fix issue with forward declaring enums. Only forward dclare enum typedef
 * If two or more leafs under a node have same name, disambiguate them

#345