### PR TITLE
Replace unique_ptr with shared_ptr

### DIFF
--- a/sdk/cpp/core/samples/bgp.cpp
+++ b/sdk/cpp/core/samples/bgp.cpp
@@ -90,7 +90,7 @@ void test_bgp_create()
 
 
     // TODO fix rpc
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
 
     // call create

--- a/sdk/cpp/core/src/crud_service.cpp
+++ b/sdk/cpp/core/src/crud_service.cpp
@@ -33,10 +33,10 @@ using namespace std;
 namespace ydk {
 
 static string get_data_payload(Entity & entity, path::ServiceProvider & provider);
-static std::unique_ptr<path::DataNode> execute_rpc(path::ServiceProvider & provider, Entity & entity,
+static std::shared_ptr<path::DataNode> execute_rpc(path::ServiceProvider & provider, Entity & entity,
 		const string & operation, const string & data_tag, bool set_config_flag);
-static unique_ptr<Entity> get_top_entity_from_filter(Entity & filter);
-static bool operation_succeeded(unique_ptr<path::DataNode> node);
+static shared_ptr<Entity> get_top_entity_from_filter(Entity & filter);
+static bool operation_succeeded(shared_ptr<path::DataNode> node);
 
 CrudService::CrudService()
 {
@@ -66,34 +66,34 @@ bool CrudService::delete_(path::ServiceProvider & provider, Entity & entity)
 			);
 }
 
-unique_ptr<Entity> CrudService::read(path::ServiceProvider & provider, Entity & filter)
+shared_ptr<Entity> CrudService::read(path::ServiceProvider & provider, Entity & filter)
 {
 	YLOG_DEBUG("Executing CRUD read operation");
 	return read_datanode(filter, execute_rpc(provider, filter, "ydk:read", "filter", false));
 }
 
-unique_ptr<Entity> CrudService::read_config(path::ServiceProvider & provider, Entity & filter)
+shared_ptr<Entity> CrudService::read_config(path::ServiceProvider & provider, Entity & filter)
 {
 	YLOG_DEBUG("Executing CRUD config read operation");
 	return read_datanode(filter, execute_rpc(provider, filter, "ydk:read", "filter", true));
 }
 
-unique_ptr<Entity> CrudService::read_datanode(Entity & filter, unique_ptr<path::DataNode> read_data_node)
+shared_ptr<Entity> CrudService::read_datanode(Entity & filter, shared_ptr<path::DataNode> read_data_node)
 {
     if (read_data_node == nullptr)
         return {};
-    unique_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
+    shared_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
     get_entity_from_data_node(read_data_node->children()[0].get(), top_entity.get());
     return top_entity;
 }
 
-static bool operation_succeeded(unique_ptr<path::DataNode> node)
+static bool operation_succeeded(shared_ptr<path::DataNode> node)
 {
 	YLOG_DEBUG("Operation {}", ((node == nullptr)?"succeeded":"failed"));
 	return node == nullptr;
 }
 
-static unique_ptr<Entity> get_top_entity_from_filter(Entity & filter)
+static shared_ptr<Entity> get_top_entity_from_filter(Entity & filter)
 {
     if(filter.parent == nullptr)
         return filter.clone_ptr();
@@ -101,11 +101,11 @@ static unique_ptr<Entity> get_top_entity_from_filter(Entity & filter)
     return get_top_entity_from_filter(*(filter.parent));
 }
 
-static unique_ptr<path::DataNode> execute_rpc(path::ServiceProvider & provider, Entity & entity,
+static shared_ptr<path::DataNode> execute_rpc(path::ServiceProvider & provider, Entity & entity,
         const string & operation, const string & data_tag, bool set_config_flag)
 {
     path::RootSchemaNode& root_schema = provider.get_root_schema();
-    unique_ptr<ydk::path::Rpc> ydk_rpc { root_schema.rpc(operation) };
+    shared_ptr<ydk::path::Rpc> ydk_rpc { root_schema.rpc(operation) };
     string data = get_data_payload(entity, provider);
 
     if(set_config_flag)

--- a/sdk/cpp/core/src/crud_service.hpp
+++ b/sdk/cpp/core/src/crud_service.hpp
@@ -55,13 +55,12 @@ class CrudService : public Service
 
         bool delete_(path::ServiceProvider & provider, Entity & entity);
 
-        std::unique_ptr<Entity> read(path::ServiceProvider & provider, Entity & filter);
+        std::shared_ptr<Entity> read(path::ServiceProvider & provider, Entity & filter);
 
-        std::unique_ptr<Entity> read_config(path::ServiceProvider & provider, Entity & filter);
+        std::shared_ptr<Entity> read_config(path::ServiceProvider & provider, Entity & filter);
 
     private:
-        std::unique_ptr<Entity> read_datanode(Entity & filter, std::unique_ptr<path::DataNode>
-         read_data_node);
+        std::shared_ptr<Entity> read_datanode(Entity & filter, std::shared_ptr<path::DataNode> read_data_node);
 };
 
 }

--- a/sdk/cpp/core/src/entity.cpp
+++ b/sdk/cpp/core/src/entity.cpp
@@ -40,25 +40,19 @@ Entity::~Entity()
 {
 }
 
-unique_ptr<Entity> Entity::clone_ptr()
+shared_ptr<Entity> Entity::clone_ptr()
 {
     return nullptr;
 }
 
-void Entity::set_child(const std::string & yang_name, Entity* entity)
+void Entity::set_parent(Entity* p)
 {
-    children[yang_name] = entity;
+    parent = p;
 }
 
-Entity* Entity::get_child(const std::string & yang_name)
+Entity* Entity::get_parent()
 {
-    return children[yang_name];
+    return parent;
 }
-
-std::map<std::string, Entity*> & Entity::get_protected_children()
-{
-    return children;
-}
-
 
 }

--- a/sdk/cpp/core/src/entity_util.cpp
+++ b/sdk/cpp/core/src/entity_util.cpp
@@ -32,8 +32,10 @@ using namespace std;
 namespace ydk
 {
 
-void get_relative_entity_path(const Entity* current_node, const Entity* ancestor, std::ostringstream & path_buffer)
+std::string get_relative_entity_path(const Entity* current_node, const Entity* ancestor, std::string path)
 {
+    std::ostringstream path_buffer;
+    path_buffer << path;
     if(ancestor == nullptr)
     {
         throw(YCPPInvalidArgumentError{"ancestor should not be null."});
@@ -63,6 +65,8 @@ void get_relative_entity_path(const Entity* current_node, const Entity* ancestor
     if(p)
         path_buffer << "/";
     path_buffer<<current_node->get_segment_path();
+    return path_buffer.str();
+
 }
 
 bool is_set(const EditOperation & operation)

--- a/sdk/cpp/core/src/entity_util.hpp
+++ b/sdk/cpp/core/src/entity_util.hpp
@@ -30,7 +30,7 @@ namespace ydk
 {
 class Entity;
 
-void get_relative_entity_path(const Entity* current_node, const Entity* ancestor, std::ostringstream & path_buffer);
+std::string get_relative_entity_path(const Entity* current_node, const Entity* ancestor, std::string path);
 bool is_set(const EditOperation & operation);
 
 }

--- a/sdk/cpp/core/src/ietf_netconf.cpp
+++ b/sdk/cpp/core/src/ietf_netconf.cpp
@@ -44,7 +44,7 @@ EntityPath GetConfigRpc::Output::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -125,7 +125,7 @@ EntityPath GetConfigRpc::Source::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -311,7 +311,7 @@ void GetConfigRpc::set_value(const std::string & value_path, std::string value)
     }
 }
 
-std::unique_ptr<Entity> GetConfigRpc::clone_ptr()
+std::shared_ptr<Entity> GetConfigRpc::clone_ptr()
 {
     return std::make_unique<GetConfigRpc>();
 }
@@ -358,7 +358,7 @@ EntityPath EditConfigRpc::Target::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -534,7 +534,7 @@ void EditConfigRpc::set_value(const std::string & value_path, std::string value)
     }
 }
 
-std::unique_ptr<Entity> EditConfigRpc::clone_ptr()
+std::shared_ptr<Entity> EditConfigRpc::clone_ptr()
 {
     return std::make_unique<EditConfigRpc>();
 }
@@ -587,7 +587,7 @@ EntityPath CopyConfigRpc::Target::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -691,7 +691,7 @@ EntityPath CopyConfigRpc::Source::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -882,7 +882,7 @@ void CopyConfigRpc::set_value(const std::string & value_path, std::string value)
     }
 }
 
-std::unique_ptr<Entity> CopyConfigRpc::clone_ptr()
+std::shared_ptr<Entity> CopyConfigRpc::clone_ptr()
 {
     return std::make_unique<CopyConfigRpc>();
 }
@@ -929,7 +929,7 @@ EntityPath DeleteConfigRpc::Target::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1072,7 +1072,7 @@ void DeleteConfigRpc::set_value(const std::string & value_path, std::string valu
 {
 }
 
-std::unique_ptr<Entity> DeleteConfigRpc::clone_ptr()
+std::shared_ptr<Entity> DeleteConfigRpc::clone_ptr()
 {
     return std::make_unique<DeleteConfigRpc>();
 }
@@ -1122,7 +1122,7 @@ EntityPath LockRpc::Target::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1270,7 +1270,7 @@ void LockRpc::set_value(const std::string & value_path, std::string value)
 {
 }
 
-std::unique_ptr<Entity> LockRpc::clone_ptr()
+std::shared_ptr<Entity> LockRpc::clone_ptr()
 {
     return std::make_unique<LockRpc>();
 }
@@ -1320,7 +1320,7 @@ EntityPath UnlockRpc::Target::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1468,7 +1468,7 @@ void UnlockRpc::set_value(const std::string & value_path, std::string value)
 {
 }
 
-std::unique_ptr<Entity> UnlockRpc::clone_ptr()
+std::shared_ptr<Entity> UnlockRpc::clone_ptr()
 {
     return std::make_unique<UnlockRpc>();
 }
@@ -1509,7 +1509,7 @@ EntityPath GetRpc::Output::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1651,7 +1651,7 @@ void GetRpc::set_value(const std::string & value_path, std::string value)
     }
 }
 
-std::unique_ptr<Entity> GetRpc::clone_ptr()
+std::shared_ptr<Entity> GetRpc::clone_ptr()
 {
     return std::make_unique<GetRpc>();
 }
@@ -1724,7 +1724,7 @@ void CloseSessionRpc::set_value(const std::string & value_path, std::string valu
 {
 }
 
-std::unique_ptr<Entity> CloseSessionRpc::clone_ptr()
+std::shared_ptr<Entity> CloseSessionRpc::clone_ptr()
 {
     return std::make_unique<CloseSessionRpc>();
 }
@@ -1805,7 +1805,7 @@ void KillSessionRpc::set_value(const std::string & value_path, std::string value
     }
 }
 
-std::unique_ptr<Entity> KillSessionRpc::clone_ptr()
+std::shared_ptr<Entity> KillSessionRpc::clone_ptr()
 {
     return std::make_unique<KillSessionRpc>();
 }
@@ -1910,7 +1910,7 @@ void CommitRpc::set_value(const std::string & value_path, std::string value)
     }
 }
 
-std::unique_ptr<Entity> CommitRpc::clone_ptr()
+std::shared_ptr<Entity> CommitRpc::clone_ptr()
 {
     return std::make_unique<CommitRpc>();
 }
@@ -1983,7 +1983,7 @@ void DiscardChangesRpc::set_value(const std::string & value_path, std::string va
 {
 }
 
-std::unique_ptr<Entity> DiscardChangesRpc::clone_ptr()
+std::shared_ptr<Entity> DiscardChangesRpc::clone_ptr()
 {
     return std::make_unique<DiscardChangesRpc>();
 }
@@ -2064,7 +2064,7 @@ void CancelCommitRpc::set_value(const std::string & value_path, std::string valu
     }
 }
 
-std::unique_ptr<Entity> CancelCommitRpc::clone_ptr()
+std::shared_ptr<Entity> CancelCommitRpc::clone_ptr()
 {
     return std::make_unique<CancelCommitRpc>();
 }
@@ -2117,7 +2117,7 @@ EntityPath ValidateRpc::Source::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -2270,7 +2270,7 @@ void ValidateRpc::set_value(const std::string & value_path, std::string value)
 {
 }
 
-std::unique_ptr<Entity> ValidateRpc::clone_ptr()
+std::shared_ptr<Entity> ValidateRpc::clone_ptr()
 {
     return std::make_unique<ValidateRpc>();
 }

--- a/sdk/cpp/core/src/ietf_netconf.hpp
+++ b/sdk/cpp/core/src/ietf_netconf.hpp
@@ -25,7 +25,7 @@ class GetConfigRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
         YLeaf with_defaults; //type: WithDefaultsModeEnum
 
 
@@ -92,7 +92,7 @@ class EditConfigRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
         YLeaf default_operation; //type: DefaultOperationEnum
         YLeaf test_option; //type: TestOptionEnum
         YLeaf error_option; //type: ErrorOptionEnum
@@ -142,7 +142,7 @@ class CopyConfigRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
         YLeaf with_defaults; //type: WithDefaultsModeEnum
 
 
@@ -214,7 +214,7 @@ class DeleteConfigRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
 
 
     class Target : public Entity
@@ -257,7 +257,7 @@ class LockRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
 
 
     class Target : public Entity
@@ -301,7 +301,7 @@ class UnlockRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
 
 
     class Target : public Entity
@@ -345,7 +345,7 @@ class GetRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
         YLeaf with_defaults; //type: WithDefaultsModeEnum
 
 
@@ -388,7 +388,7 @@ class CloseSessionRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
 
 
 
@@ -408,7 +408,7 @@ class KillSessionRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
         YLeaf session_id; //type: uint32
 
 
@@ -429,7 +429,7 @@ class CommitRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
         YLeaf confirmed; //type: empty
         YLeaf confirm_timeout; //type: uint32
         YLeaf persist; //type: string
@@ -453,7 +453,7 @@ class DiscardChangesRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
 
 
 
@@ -473,7 +473,7 @@ class CancelCommitRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
         YLeaf persist_id; //type: string
 
 
@@ -494,7 +494,7 @@ class ValidateRpc : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
 
 
     class Source : public Entity

--- a/sdk/cpp/core/src/netconf_provider.hpp
+++ b/sdk/cpp/core/src/netconf_provider.hpp
@@ -39,13 +39,13 @@ public:
                                int port = 830);
         ~NetconfServiceProvider();
         path::RootSchemaNode& get_root_schema() const;
-        std::unique_ptr<path::DataNode> invoke(path::Rpc& rpc) const;
+        std::shared_ptr<path::DataNode> invoke(path::Rpc& rpc) const;
         EncodingFormat get_encoding() const;
 
 private:
-        std::unique_ptr<path::DataNode> handle_edit(path::Rpc& rpc, path::Annotation ann) const;
-        std::unique_ptr<path::DataNode> handle_netconf_operation(path::Rpc& ydk_rpc) const;
-        std::unique_ptr<path::DataNode> handle_read(path::Rpc& rpc) const;
+        std::shared_ptr<path::DataNode> handle_edit(path::Rpc& rpc, path::Annotation ann) const;
+        std::shared_ptr<path::DataNode> handle_netconf_operation(path::Rpc& ydk_rpc) const;
+        std::shared_ptr<path::DataNode> handle_read(path::Rpc& rpc) const;
         void initialize(path::Repository& repo);
 
 private:

--- a/sdk/cpp/core/src/netconf_service.cpp
+++ b/sdk/cpp/core/src/netconf_service.cpp
@@ -35,8 +35,8 @@ using namespace std;
 namespace ydk {
 
 static std::string get_data_payload(Entity& entity, path::RootSchemaNode& root_schema);
-static unique_ptr<Entity> get_top_entity_from_filter(Entity & filter);
-static unique_ptr<path::Rpc> get_rpc_instance(NetconfServiceProvider & provider, string && operation);
+static shared_ptr<Entity> get_top_entity_from_filter(Entity & filter);
+static shared_ptr<path::Rpc> get_rpc_instance(NetconfServiceProvider & provider, string && operation);
 static void create_input_leaf(path::DataNode & input_datanode, DataStore datastore, string && datastore_string, string & url);
 static void create_input_leaf(path::DataNode & input_datanode, DataStore datastore, string && datastore_string);
 
@@ -54,7 +54,7 @@ bool NetconfService::cancel_commit(NetconfServiceProvider & provider, int persis
 	YLOG_DEBUG("Executing cancel-commit RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:cancel-commit");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:cancel-commit");
 
     if (persist_id > -1)
     {
@@ -71,7 +71,7 @@ bool NetconfService::close_session(NetconfServiceProvider & provider)
 	YLOG_DEBUG("Executing close-session RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:close-session");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:close-session");
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -84,7 +84,7 @@ bool NetconfService::commit(NetconfServiceProvider & provider, bool confirmed,
 	YLOG_DEBUG("Executing commit RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:commit");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:commit");
 
     if (confirmed)
     {
@@ -116,7 +116,7 @@ bool NetconfService::copy_config(NetconfServiceProvider & provider, DataStore ta
 	YLOG_DEBUG("Executing copy-config RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:copy-config");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:copy-config");
 
     // target options: candidate | running | startup | url
     create_input_leaf(rpc->input(), target, "target", url);
@@ -131,7 +131,7 @@ bool NetconfService::copy_config(NetconfServiceProvider & provider, DataStore ta
 	YLOG_DEBUG("Executing copy-config RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:copy-config");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:copy-config");
 
     // target options: candidate | running | startup | url
     create_input_leaf(rpc->input(), target, "target");
@@ -150,7 +150,7 @@ bool NetconfService::delete_config(NetconfServiceProvider & provider, DataStore 
 	YLOG_DEBUG("Executing delete-config RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:delete-config");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:delete-config");
 
     // target options: startup | url
     create_input_leaf(rpc->input(), target, "target", url);
@@ -165,7 +165,7 @@ bool NetconfService::discard_changes(NetconfServiceProvider & provider)
 	YLOG_DEBUG("Executing discard-changes RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:discard-changes");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:discard-changes");
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -178,7 +178,7 @@ bool NetconfService::edit_config(NetconfServiceProvider & provider, DataStore ta
 	YLOG_DEBUG("Executing edit-config RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:edit-config");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:edit-config");
 
     // target options: candidate | running
     create_input_leaf(rpc->input(), target, "target");
@@ -207,12 +207,12 @@ bool NetconfService::edit_config(NetconfServiceProvider & provider, DataStore ta
 }
 
 //get_config
-unique_ptr<Entity> NetconfService::get_config(NetconfServiceProvider & provider, DataStore source, Entity& filter)
+shared_ptr<Entity> NetconfService::get_config(NetconfServiceProvider & provider, DataStore source, Entity& filter)
 {
 	YLOG_DEBUG("Executing get-config RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:get-config");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:get-config");
 
     // source options: candidate | running | startup
     create_input_leaf(rpc->input(), source, "source");
@@ -225,19 +225,19 @@ unique_ptr<Entity> NetconfService::get_config(NetconfServiceProvider & provider,
     if (read_datanode == nullptr)
         return nullptr;
 
-    unique_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
+    shared_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
     get_entity_from_data_node(read_datanode->children()[0].get(), top_entity.get());
     return top_entity;
 
 }
 
 //get
-unique_ptr<Entity> NetconfService::get(NetconfServiceProvider & provider, Entity& filter)
+shared_ptr<Entity> NetconfService::get(NetconfServiceProvider & provider, Entity& filter)
 {
 	YLOG_DEBUG("Executing get RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:get");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:get");
 
     // filter
     std::string entity_string = get_data_payload(filter, provider.get_root_schema());
@@ -246,7 +246,7 @@ unique_ptr<Entity> NetconfService::get(NetconfServiceProvider & provider, Entity
     auto result_datanode = (*rpc)(provider);
     if (result_datanode == nullptr)
         return {};
-    unique_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
+    shared_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
     get_entity_from_data_node(result_datanode->children()[0].get(), top_entity.get());
     return top_entity;
 }
@@ -257,7 +257,7 @@ bool NetconfService::kill_session(NetconfServiceProvider & provider, int session
 	YLOG_DEBUG("Executing kill-session RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:kill-session");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:kill-session");
 
     std::string sid_string = std::to_string(session_id);
     rpc->input().create("session-id", sid_string);
@@ -272,7 +272,7 @@ bool NetconfService::lock(NetconfServiceProvider & provider, DataStore target)
 	YLOG_DEBUG("Executing lock RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:lock");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:lock");
 
     // target options: candidate | running | startup
     create_input_leaf(rpc->input(), target, "target");
@@ -287,7 +287,7 @@ bool NetconfService::unlock(NetconfServiceProvider & provider, DataStore target)
 	YLOG_DEBUG("Executing unlock RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:unlock");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:unlock");
 
     // target options: candidate | running | startup
     create_input_leaf(rpc->input(), target, "target");
@@ -302,7 +302,7 @@ bool NetconfService::validate(NetconfServiceProvider & provider, DataStore sourc
 	YLOG_DEBUG("Executing validate RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:validate");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:validate");
 
     // source options: candidate | running | startup | url
     create_input_leaf(rpc->input(), source, "source", url);
@@ -316,7 +316,7 @@ bool NetconfService::validate(NetconfServiceProvider & provider, Entity& source)
 	YLOG_DEBUG("Executing validate RPC");
 
     // Get the root schema node
-    unique_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:validate");
+    shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:validate");
 
     // source
     std::string entity_string = get_data_payload(source, provider.get_root_schema());
@@ -326,7 +326,7 @@ bool NetconfService::validate(NetconfServiceProvider & provider, Entity& source)
     return read_datanode == nullptr;
 }
 
-static unique_ptr<path::Rpc> get_rpc_instance(NetconfServiceProvider & provider, string && operation)
+static shared_ptr<path::Rpc> get_rpc_instance(NetconfServiceProvider & provider, string && operation)
 {
 	path::RootSchemaNode & root_schema = provider.get_root_schema();
 	auto rpc =  root_schema.rpc(operation);
@@ -343,7 +343,7 @@ static std::string get_data_payload(Entity & entity, path::RootSchemaNode & root
     return codec.encode(data_node, ydk::EncodingFormat::XML, true);
 }
 
-static unique_ptr<Entity> get_top_entity_from_filter(Entity & filter)
+static shared_ptr<Entity> get_top_entity_from_filter(Entity & filter)
 {
     if(filter.parent == nullptr)
         return filter.clone_ptr();

--- a/sdk/cpp/core/src/netconf_service.hpp
+++ b/sdk/cpp/core/src/netconf_service.hpp
@@ -77,9 +77,9 @@ class NetconfService : public Service
         bool edit_config(NetconfServiceProvider & provider, DataStore target, Entity& config,
             std::string default_operation = "", std::string test_option = "", std::string error_option = "");
 
-        std::unique_ptr<Entity> get_config(NetconfServiceProvider & provider, DataStore source, Entity& filter);
+        std::shared_ptr<Entity> get_config(NetconfServiceProvider & provider, DataStore source, Entity& filter);
 
-        std::unique_ptr<Entity> get(NetconfServiceProvider & provider, Entity& filter);
+        std::shared_ptr<Entity> get(NetconfServiceProvider & provider, Entity& filter);
 
         bool kill_session(NetconfServiceProvider & provider, int session_id);
 

--- a/sdk/cpp/core/src/network_topology.cpp
+++ b/sdk/cpp/core/src/network_topology.cpp
@@ -44,7 +44,7 @@ EntityPath NetworkTopology::Topology::TopologyTypes::TopologyNetconf::get_entity
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -122,7 +122,7 @@ EntityPath NetworkTopology::Topology::TopologyTypes::get_entity_path(Entity* anc
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -220,7 +220,7 @@ EntityPath NetworkTopology::Topology::UnderlayTopology::get_entity_path(Entity* 
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -303,7 +303,7 @@ EntityPath NetworkTopology::Topology::Node::SupportingNode::get_entity_path(Enti
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -400,7 +400,7 @@ EntityPath NetworkTopology::Topology::Node::TerminationPoint::get_entity_path(En
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -498,7 +498,7 @@ EntityPath NetworkTopology::Topology::Node::YangModuleCapabilities::get_entity_p
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -587,7 +587,7 @@ EntityPath NetworkTopology::Topology::Node::ClusteredConnectionStatus::NodeStatu
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -682,7 +682,7 @@ EntityPath NetworkTopology::Topology::Node::ClusteredConnectionStatus::get_entit
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -791,7 +791,7 @@ EntityPath NetworkTopology::Topology::Node::AvailableCapabilities::AvailableCapa
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -883,7 +883,7 @@ EntityPath NetworkTopology::Topology::Node::AvailableCapabilities::get_entity_pa
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -987,7 +987,7 @@ EntityPath NetworkTopology::Topology::Node::UnavailableCapabilities::Unavailable
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1079,7 +1079,7 @@ EntityPath NetworkTopology::Topology::Node::UnavailableCapabilities::get_entity_
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1177,7 +1177,7 @@ EntityPath NetworkTopology::Topology::Node::PassThrough::get_entity_path(Entity*
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1258,7 +1258,7 @@ EntityPath NetworkTopology::Topology::Node::YangLibrary::get_entity_path(Entity*
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1456,7 +1456,7 @@ EntityPath NetworkTopology::Topology::Node::get_entity_path(Entity* ancestor) co
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1814,7 +1814,7 @@ EntityPath NetworkTopology::Topology::Link::Source::get_entity_path(Entity* ance
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1902,7 +1902,7 @@ EntityPath NetworkTopology::Topology::Link::Destination::get_entity_path(Entity*
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -1987,7 +1987,7 @@ EntityPath NetworkTopology::Topology::Link::SupportingLink::get_entity_path(Enti
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -2090,7 +2090,7 @@ EntityPath NetworkTopology::Topology::Link::get_entity_path(Entity* ancestor) co
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -2282,7 +2282,7 @@ EntityPath NetworkTopology::Topology::get_entity_path(Entity* ancestor) const
     }
     else
     {
-        get_relative_entity_path(this, ancestor, path_buffer);
+        path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());
     }
 
     std::vector<std::pair<std::string, LeafData> > leaf_name_data {};
@@ -2533,7 +2533,7 @@ void NetworkTopology::set_value(const std::string & value_path, std::string valu
 {
 }
 
-std::unique_ptr<Entity> NetworkTopology::clone_ptr()
+std::shared_ptr<Entity> NetworkTopology::clone_ptr()
 {
     return std::make_unique<NetworkTopology>();
 }

--- a/sdk/cpp/core/src/network_topology.hpp
+++ b/sdk/cpp/core/src/network_topology.hpp
@@ -23,7 +23,7 @@ class NetworkTopology : public Entity
         Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path) override;
         void set_value(const std::string & value_path, std::string value) override;
         std::map<std::string, Entity*> & get_children() override;
-        std::unique_ptr<Entity> clone_ptr() override;
+        std::shared_ptr<Entity> clone_ptr() override;
 
 
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -93,7 +93,7 @@ namespace ydk {
 
             DataNode& create(const std::string& path, const std::string& value);
 
-            std::unique_ptr<Rpc> rpc(const std::string& path) const;
+            std::shared_ptr<Rpc> rpc(const std::string& path) const;
 
 
             struct ly_ctx* m_ctx;
@@ -200,8 +200,7 @@ namespace ydk {
 
             ~RpcImpl();
 
-            std::unique_ptr<DataNode>
-             operator()(const ServiceProvider& provider);
+            std::shared_ptr<DataNode> operator()(const ServiceProvider& provider);
 
             DataNode& input() const;
 

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -149,7 +149,7 @@ ydk::path::RootSchemaNodeImpl::create(const std::string& path, const std::string
     return m_root_data_nodes.back()->create(path, value);
 }
 
-std::unique_ptr<ydk::path::Rpc>
+std::shared_ptr<ydk::path::Rpc>
 ydk::path::RootSchemaNodeImpl::rpc(const std::string& path) const
 {
     auto c = find(path);
@@ -179,5 +179,5 @@ ydk::path::RootSchemaNodeImpl::rpc(const std::string& path) const
         throw(YCPPIllegalStateError("Internal error occurred"));
     }
 
-    return std::make_unique<RpcImpl>(*sn, m_ctx);
+    return std::make_shared<RpcImpl>(*sn, m_ctx);
 }

--- a/sdk/cpp/core/src/path/rpc.cpp
+++ b/sdk/cpp/core/src/path/rpc.cpp
@@ -55,7 +55,7 @@ ydk::path::RpcImpl::~RpcImpl()
 {
 }
 
-std::unique_ptr<ydk::path::DataNode>
+std::shared_ptr<ydk::path::DataNode>
 ydk::path::RpcImpl::operator()(const ydk::path::ServiceProvider& provider)
 {
     return provider.invoke(*this);

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -659,7 +659,7 @@ public:
     /// @throws YCPPInvalidArgumentError if the argument is invalid.
     /// @throws YCPPPathError if the path is invalid
     ///
-    virtual std::unique_ptr<Rpc> rpc(const std::string& path) const = 0;
+    virtual std::shared_ptr<Rpc> rpc(const std::string& path) const = 0;
 
 };
 
@@ -996,7 +996,7 @@ public:
     /// @param[in] pointer to the Rpc node
     /// @return The pointer to the DataNode representing the output.
     ///
-    virtual std::unique_ptr<DataNode> invoke(Rpc& rpc) const = 0 ;
+    virtual std::shared_ptr<DataNode> invoke(Rpc& rpc) const = 0 ;
 
 };
 
@@ -1022,7 +1022,7 @@ public:
     /// @param[in] sp The Service provider
     /// @areturn pointer to the DataNode or nullptr if none exists
     ///
-    virtual std::unique_ptr<DataNode> operator()(const ServiceProvider& provider) = 0;
+    virtual std::shared_ptr<DataNode> operator()(const ServiceProvider& provider) = 0;
 
     ///
     /// @brief get the input data tree

--- a/sdk/cpp/core/src/restconf_provider.hpp
+++ b/sdk/cpp/core/src/restconf_provider.hpp
@@ -52,12 +52,12 @@ public:
         ~RestconfServiceProvider();
 
         path::RootSchemaNode& get_root_schema() const;
-        std::unique_ptr<path::DataNode> invoke(path::Rpc& rpc) const;
+        std::shared_ptr<path::DataNode> invoke(path::Rpc& rpc) const;
         EncodingFormat get_encoding() const;
 
 private:
-        std::unique_ptr<path::DataNode> handle_edit(path::Rpc& rpc, const std::string & operation) const;
-        std::unique_ptr<path::DataNode> handle_read(path::Rpc& rpc) const;
+        std::shared_ptr<path::DataNode> handle_edit(path::Rpc& rpc, const std::string & operation) const;
+        std::shared_ptr<path::DataNode> handle_read(path::Rpc& rpc) const;
         void initialize(path::Repository & repo);
 
 private:

--- a/sdk/cpp/core/src/types.hpp
+++ b/sdk/cpp/core/src/types.hpp
@@ -137,18 +137,16 @@ class Entity {
     virtual Entity* get_child_by_name(const std::string & yang_name, const std::string & segment_path="") = 0;
 
     virtual std::map<std::string, Entity*> & get_children() = 0;
-    virtual std::unique_ptr<Entity> clone_ptr();
-    virtual void set_child(const std::string & yang_name, Entity* entity);
-    virtual Entity* get_child(const std::string & yang_name);
-    virtual std::map<std::string, Entity*> & get_protected_children();
+    virtual std::shared_ptr<Entity> clone_ptr();
+
+    virtual void set_parent(Entity* p);
+    virtual Entity* get_parent();
 
   public:
     Entity* parent;
     std::string yang_name;
     std::string yang_parent_name;
     EditOperation operation;
-
-  protected:
     std::map<std::string, Entity*> children;
 };
 
@@ -301,7 +299,7 @@ class YLeaf
 class YLeafList {
   public:
     YLeafList(YType type, std::string name);
-    ~YLeafList();
+    virtual ~YLeafList();
 
     YLeafList(const YLeafList& val);
     YLeafList(YLeafList&& val);
@@ -309,29 +307,29 @@ class YLeafList {
     YLeafList& operator=(const YLeafList& val);
     YLeafList& operator=(YLeafList&& val);
 
-    void append(uint8 val);
-    void append(uint32 val);
-    void append(uint64 val);
-    void append(long val);
-    void append(int8 val);
-    void append(int32 val);
-    void append(int64 val);
-    void append(double val);
-    void append(Empty val);
-    void append(Identity val);
-    void append(Bits val);
-    void append(std::string val);
-    void append(Enum::YLeaf val);
-    void append(Decimal64 val);
+    virtual void append(uint8 val);
+    virtual void append(uint32 val);
+    virtual void append(uint64 val);
+    virtual void append(long val);
+    virtual void append(int8 val);
+    virtual void append(int32 val);
+    virtual void append(int64 val);
+    virtual void append(double val);
+    virtual void append(Empty val);
+    virtual void append(Identity val);
+    virtual void append(Bits val);
+    virtual void append(std::string val);
+    virtual void append(Enum::YLeaf val);
+    virtual void append(Decimal64 val);
 
-    YLeaf & operator [] (size_t index);
+    virtual YLeaf & operator [] (size_t index);
 
     operator std::string() const;
     bool operator == (YLeafList & other) const;
     bool operator == (const YLeafList & other) const;
 
-    std::vector<std::pair<std::string, LeafData> > get_name_leafdata() const;
-    std::vector<YLeaf> getYLeafs() const;
+    virtual std::vector<std::pair<std::string, LeafData> > get_name_leafdata() const;
+    virtual std::vector<YLeaf> getYLeafs() const;
 
   public:
     EditOperation operation;

--- a/sdk/cpp/core/src/value_list.cpp
+++ b/sdk/cpp/core/src/value_list.cpp
@@ -131,6 +131,15 @@ void YLeafList::append(long val)
 	values.push_back(value);
 }
 
+void YLeafList::append(double val)
+{
+    YLeaf value {type, name};
+    value = val;
+
+
+    values.push_back(value);
+}
+
 void YLeafList::append(int8 val)
 {
 	YLeaf value {type, name};

--- a/sdk/cpp/core/tests/bgptest.cpp
+++ b/sdk/cpp/core/tests/bgptest.cpp
@@ -52,7 +52,7 @@ public:
 		return ydk::EncodingFormat::XML;
 	}
 
-	std::unique_ptr<ydk::path::DataNode> invoke(ydk::path::Rpc& rpc) const
+	std::shared_ptr<ydk::path::DataNode> invoke(ydk::path::Rpc& rpc) const
 	{
         ydk::path::CodecService s{};
 

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -98,7 +98,7 @@ TEST_CASE( "bgp_netconf_create" )
 
     auto & bgp = schema.create("openconfig-bgp:bgp", "");
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 
@@ -138,12 +138,12 @@ TEST_CASE( "bgp_netconf_create" )
     REQUIRE(xml == expected_bgp_output);
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & bgp_read = schema.create("openconfig-bgp:bgp", "");
 
     xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
@@ -163,7 +163,7 @@ TEST_CASE( "bgp_netconf_create" )
     peer_as.set("6500");
 
     //call update
-    std::unique_ptr<ydk::path::Rpc> update_rpc { schema.rpc("ydk:update") };
+    std::shared_ptr<ydk::path::Rpc> update_rpc { schema.rpc("ydk:update") };
     xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
     update_rpc->input().create("entity", xml);
@@ -183,7 +183,7 @@ TEST_CASE("bits")
 	auto & runner = schema.create("ydktest-sanity:runner", "");
 
 	//get the root
-	std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+	std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 	REQUIRE( data_root != nullptr );
 
 	auto & ysanity = runner.create("ytypes/built-in-t/bits-value", "disable-nagle");
@@ -195,7 +195,7 @@ TEST_CASE("bits")
 
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 }
@@ -210,7 +210,7 @@ TEST_CASE("core_validate")
     auto & runner = schema.create("ietf-netconf:validate", "");
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
     REQUIRE( data_root != nullptr );
 
     auto & ysanity = runner.create("source/candidate", "");
@@ -223,7 +223,7 @@ TEST_CASE("core_validate")
     std::cout << xml << std::endl;
 
     //call create
-    // std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    // std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     // create_rpc->input().create("entity", xml);
     // (*create_rpc)(sp);
 }
@@ -240,7 +240,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
 
     auto & bgp = schema.create("openconfig-bgp:bgp", "");
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&bgp.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&bgp.root()};
 
     REQUIRE( data_root != nullptr );
 
@@ -260,7 +260,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
     auto & peer_group_name = ppeer_group.create("config/peer-group-name", "IBGP");
     auto & ppeer_as = ppeer_group.create("config/peer-as","65172");
 
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
     create_rpc->input().create("entity", xml);
@@ -268,11 +268,11 @@ TEST_CASE( "bgp_xr_openconfig"  )
     auto res = (*create_rpc)(sp);
 
 	//call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & bgp_read = schema.create("openconfig-bgp:bgp", "");
 
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&bgp_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&bgp_read.root()};
 
     xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -306,7 +306,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
 //
 //    auto & vrf = four_instance_as->create("vrfs/vrf[vrf-name='red']");
 //
-//	std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+//	std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
 //	auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 //	REQUIRE( !xml.empty() );
 //	create_rpc->input().create("entity", xml);
@@ -314,9 +314,9 @@ TEST_CASE( "bgp_xr_openconfig"  )
 //	auto res = (*create_rpc)(sp);
 //
 //	//call read
-//    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+//    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
 //    auto & bgp_read = schema.create("Cisco-IOS-XR-ipv4-bgp-cfg:bgp", "");
-//    std::unique_ptr<const ydk::path::DataNode> data_root2{&bgp_read.root()};
+//    std::shared_ptr<const ydk::path::DataNode> data_root2{&bgp_read.root()};
 //
 //    xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
 //    REQUIRE( !xml.empty() );

--- a/sdk/cpp/tests/test_restconf_provider.cpp
+++ b/sdk/cpp/tests/test_restconf_provider.cpp
@@ -36,7 +36,7 @@ TEST_CASE("CreateDelRead")
 	auto & runner = schema.create("ydktest-sanity:runner", "");
 
 	//first delete
-	std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+	std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 	auto json = s.encode(runner, EncodingFormat::JSON, false);
 	delete_rpc->input().create("entity", json);
 	//call delete
@@ -47,12 +47,12 @@ TEST_CASE("CreateDelRead")
     json = s.encode(runner, EncodingFormat::JSON, false);
     CHECK( !json.empty());
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", json);
     (*create_rpc)(provider);
 
     //read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
 	auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
 	json = s.encode(runner_read, EncodingFormat::JSON, false);
@@ -67,7 +67,7 @@ TEST_CASE("CreateDelRead")
 	json = s.encode(runner, EncodingFormat::JSON, false);
 	CHECK( !json.empty());
 	//call update
-	std::unique_ptr<ydk::path::Rpc> update_rpc { schema.rpc("ydk:update") };
+	std::shared_ptr<ydk::path::Rpc> update_rpc { schema.rpc("ydk:update") };
 	update_rpc->input().create("entity", json);
 	(*update_rpc)(provider);
 

--- a/sdk/cpp/tests/testsanitynctest.cpp
+++ b/sdk/cpp/tests/testsanitynctest.cpp
@@ -45,12 +45,12 @@ TEST_CASE("test_sanity_types_int8 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -67,15 +67,15 @@ TEST_CASE("test_sanity_types_int8 ")
 
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -113,12 +113,12 @@ TEST_CASE("test_sanity_types_int16 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -136,15 +136,15 @@ TEST_CASE("test_sanity_types_int16 ")
 
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -182,12 +182,12 @@ TEST_CASE("test_sanity_types_int32 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -203,15 +203,15 @@ TEST_CASE("test_sanity_types_int32 ")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -247,12 +247,12 @@ TEST_CASE("test_sanity_types_int64 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -268,15 +268,15 @@ TEST_CASE("test_sanity_types_int64 ")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -312,12 +312,12 @@ TEST_CASE("test_sanity_types_uint8 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -334,15 +334,15 @@ TEST_CASE("test_sanity_types_uint8 ")
 
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -378,12 +378,12 @@ TEST_CASE("test_sanity_types_uint16 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -400,15 +400,15 @@ TEST_CASE("test_sanity_types_uint16 ")
                         );
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -444,12 +444,12 @@ TEST_CASE("test_sanity_types_uint32 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -467,15 +467,15 @@ TEST_CASE("test_sanity_types_uint32 ")
 
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -511,12 +511,12 @@ TEST_CASE("test_sanity_types_uint64 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -532,15 +532,15 @@ TEST_CASE("test_sanity_types_uint64 ")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -578,12 +578,12 @@ TEST_CASE("test_sanity_types_bits ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -600,15 +600,15 @@ TEST_CASE("test_sanity_types_bits ")
 
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -644,12 +644,12 @@ TEST_CASE("test_sanity_types_decimal64 ")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -665,15 +665,15 @@ TEST_CASE("test_sanity_types_decimal64 ")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -712,12 +712,12 @@ TEST_CASE("test_sanity_types_string")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -733,15 +733,15 @@ TEST_CASE("test_sanity_types_string")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -779,12 +779,12 @@ TEST_CASE("test_sanity_types_empty")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -800,15 +800,15 @@ TEST_CASE("test_sanity_types_empty")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -844,12 +844,12 @@ TEST_CASE("test_sanity_types_boolean")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -865,15 +865,15 @@ TEST_CASE("test_sanity_types_boolean")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -910,12 +910,12 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -931,15 +931,15 @@ TEST_CASE("test_sanity_types_embedded_enum")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -975,12 +975,12 @@ TEST_CASE("test_sanity_types_enum")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -996,15 +996,15 @@ TEST_CASE("test_sanity_types_enum")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1041,12 +1041,12 @@ TEST_CASE("test_sanity_types_union")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1062,15 +1062,15 @@ TEST_CASE("test_sanity_types_union")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1107,12 +1107,12 @@ TEST_CASE("test_sanity_types_union_enum")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1128,15 +1128,15 @@ TEST_CASE("test_sanity_types_union_enum")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1175,12 +1175,12 @@ TEST_CASE("test_sanity_types_union_int")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1197,15 +1197,15 @@ TEST_CASE("test_sanity_types_union_int")
 
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1243,12 +1243,12 @@ TEST_CASE("test_union_leaflist")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1266,15 +1266,15 @@ TEST_CASE("test_union_leaflist")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1310,12 +1310,12 @@ TEST_CASE("test_enum_leaflist")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1333,15 +1333,15 @@ TEST_CASE("test_enum_leaflist")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1377,12 +1377,12 @@ TEST_CASE("test_identity_leaflist")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1400,15 +1400,15 @@ TEST_CASE("test_identity_leaflist")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1445,12 +1445,12 @@ TEST_CASE("test_union_complex_list")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1466,15 +1466,15 @@ TEST_CASE("test_union_complex_list")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1506,12 +1506,12 @@ TEST_CASE("test_identityref")
 
 
     //get the root
-    std::unique_ptr<const ydk::path::DataNode> data_root{&runner.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
 
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::unique_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1527,16 +1527,16 @@ TEST_CASE("test_identityref")
     CHECK( !xml.empty());
 
     //call create
-    std::unique_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     create_rpc->input().create("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::unique_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
 
-    std::unique_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
+    std::shared_ptr<const ydk::path::DataNode> data_root2{&runner_read.root()};
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );

--- a/ydkgen/printer/cpp/class_get_entity_path_printer.py
+++ b/ydkgen/printer/cpp/class_get_entity_path_printer.py
@@ -120,13 +120,13 @@ class GetEntityPathPrinter(object):
             self.ctx.writeln('else')
             self.ctx.writeln('{')
             self.ctx.lvl_inc()
-            
-            self.ctx.writeln("get_relative_entity_path(this, ancestor, path_buffer);")            
+
+            self.ctx.writeln("path_buffer << get_relative_entity_path(this, ancestor, path_buffer.str());")
 
             self.ctx.lvl_dec()
             self.ctx.writeln('}')
             self.ctx.bline()
-       
+
         self.ctx.writeln('std::vector<std::pair<std::string, LeafData> > leaf_name_data {};')
         self.ctx.bline()
         for prop in leafs:

--- a/ydkgen/printer/cpp/class_members_printer.py
+++ b/ydkgen/printer/cpp/class_members_printer.py
@@ -79,7 +79,7 @@ class ClassMembersPrinter(object):
 
     def _print_clone_ptr_method(self, clazz):
         if clazz.owner is not None and isinstance(clazz.owner, Package):
-            self.ctx.writeln('std::unique_ptr<Entity> clone_ptr() override;')
+            self.ctx.writeln('std::shared_ptr<Entity> clone_ptr() override;')
 
     def _print_class_value_members(self, clazz):
         if clazz.is_identity():

--- a/ydkgen/printer/cpp/source_printer.py
+++ b/ydkgen/printer/cpp/source_printer.py
@@ -96,10 +96,10 @@ class SourcePrinter(MultiFilePrinter):
 
     def _print_clone_ptr_method(self, clazz, leafs):
         if clazz.owner is not None and isinstance(clazz.owner, Package):
-            self.ctx.writeln('std::unique_ptr<Entity> %s::clone_ptr()' % clazz.qualified_cpp_name())
+            self.ctx.writeln('std::shared_ptr<Entity> %s::clone_ptr()' % clazz.qualified_cpp_name())
             self.ctx.writeln('{')
             self.ctx.lvl_inc()
-            self.ctx.writeln('return std::make_unique<%s>();' % clazz.qualified_cpp_name())
+            self.ctx.writeln('return std::make_shared<%s>();' % clazz.qualified_cpp_name())
             self.ctx.lvl_dec()
             self.ctx.writeln('}')
 


### PR DESCRIPTION
- Replace unique_ptr with shared_ptr in for classes:
  - ydk::Entity
  - ydk::Rpc
  - ydk::path::DataNode
- Change ydk::Entity::clone_ptr signature to return shared_ptr
- Change ydk::get_relative_entity_path signature to return a std::string