### PR TITLE
Add support for content match nodes in YDK edit/read operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**
 
 - [YDK-GEN](#ydk-gen)
+  - [System requirements](#system-requirements)
   - [Installation](#installation)
     - [Setting up your environment](#setting-up-your-environment)
     - [Clone ydk-gen and install the requirements](#clone-ydk-gen-and-install-the-requirements)
@@ -43,7 +44,7 @@ Of course, many other libraries are used as an integral part of ydk-gen and its 
 The output of ydk-gen is either a core package, that defines services and providers, or a module bundle, consisting of APIs based on YANG models. Each module bundle is generated using a bundle profile and the ydk-gen tool. Developers can either use pre-packaged generated bundles (e.g. [ydk-py](http://cs.co/ydk-py)), or they can define their own bundle, consisting of a set of YANG models, using a bundle profile (e.g. [```ietf_0_1_1.json```](profiles/bundles/ietf_0_1_1.json)). This gives a developer the ability to customize the scope of their bundle based on their requirements.
 
 
-##System Requirements:
+##System requirements
 
 ####Linux
 Ubuntu (Debian-based): The following packages must be present in your system before installing YDK-Py:

--- a/sdk/cpp/core/CMakeLists.txt
+++ b/sdk/cpp/core/CMakeLists.txt
@@ -51,8 +51,7 @@ set(libydk_src
     src/executor_service.cpp
     src/ietf_parser.cpp
     src/leaf_data.cpp
-    src/netconf_client.cpp
-    src/netconf_edit_operations.cpp
+    src/netconf_client.cpp    
     src/netconf_model_provider.cpp
     src/netconf_provider.cpp
     src/netconf_service.cpp
@@ -64,6 +63,7 @@ set(libydk_src
     src/validation_service.cpp
     src/value.cpp
     src/value_list.cpp
+    src/ydk_operation.cpp
     src/ydk_yang.cpp
     src/path/annotation.cpp
     src/path/capability.cpp

--- a/sdk/cpp/core/src/codec_service.cpp
+++ b/sdk/cpp/core/src/codec_service.cpp
@@ -86,7 +86,7 @@ CodecService::encode(CodecServiceProvider & provider, std::map<std::string, std:
 }
 
 std::unique_ptr<Entity>
-CodecService::decode(CodecServiceProvider & provider, std::string & payload, std::unique_ptr<Entity> entity)
+CodecService::decode(CodecServiceProvider & provider, const std::string & payload, std::unique_ptr<Entity> entity)
 {
     auto const & bundle_name = get_bundle_name(*entity);
     provider.initialize(bundle_name, get_bundle_yang_models_location(*entity), get_augment_capabilities_function(*entity));

--- a/sdk/cpp/core/src/codec_service.hpp
+++ b/sdk/cpp/core/src/codec_service.hpp
@@ -41,7 +41,7 @@ public:
     std::string encode(CodecServiceProvider & provider, Entity & entity, bool pretty=false);
     std::map<std::string, std::string> encode(CodecServiceProvider & provider, std::map<std::string, std::unique_ptr<Entity>> & entity, bool pretty=false);
 
-    std::unique_ptr<Entity> decode(CodecServiceProvider & provider, std::string & payload, std::unique_ptr<Entity> entity);
+    std::unique_ptr<Entity> decode(CodecServiceProvider & provider, const std::string & payload, std::unique_ptr<Entity> entity);
     std::map<std::string, std::unique_ptr<Entity>> decode(CodecServiceProvider & provider,
                             std::map<std::string, std::string> & payload_map,
                             std::map<std::string, std::unique_ptr<Entity>> entity_map);

--- a/sdk/cpp/core/src/entity_data_node_walker.cpp
+++ b/sdk/cpp/core/src/entity_data_node_walker.cpp
@@ -41,7 +41,7 @@ using namespace std;
 namespace ydk
 {
 static void populate_data_node(Entity & entity, path::DataNode & data_node);
-static EntityPath get_top_entity_path(Entity & entity);
+static Entity & get_top_entity(Entity & entity);
 static void walk_children(Entity & entity, path::DataNode & data_node);
 static void populate_name_values(path::DataNode & parent_data_node, EntityPath & path);
 static bool data_node_is_leaf(path::DataNode & data_node);
@@ -57,16 +57,17 @@ static path::Annotation get_annotation(EditOperation operation);
 //////////////////////////////////////////////////////////////////////////
 path::DataNode& get_data_node_from_entity(Entity & entity, ydk::path::RootSchemaNode & root_schema)
 {
-    EntityPath root_path = get_top_entity_path(entity);
+    Entity & top_entity = get_top_entity(entity);
+    EntityPath root_path = top_entity.get_entity_path(nullptr);
     auto & root_data_node = root_schema.create(root_path.path);
-    if(is_set(entity.operation))
+    if(is_set(top_entity.operation))
     {
-        add_annotation_to_datanode(entity, root_data_node);
+        add_annotation_to_datanode(top_entity, root_data_node);
     }
 
     YLOG_TRACE("Root entity: {}", root_path.path);
     populate_name_values(root_data_node, root_path);
-    walk_children(entity, root_data_node)
+    walk_children(top_entity, root_data_node)
 ;
     return root_data_node;
 }
@@ -134,16 +135,16 @@ static void populate_name_values(path::DataNode & data_node, EntityPath & path)
         }
 
         YLOG_TRACE("Result: {}", (result?"success":"failure"));
-        }
+    }
 }
 
-static EntityPath get_top_entity_path(Entity & entity)
+static Entity & get_top_entity(Entity & entity)
 {
     if (entity.parent == nullptr)
     {
-        return entity.get_entity_path(nullptr);
+        return entity;
     }
-    return get_top_entity_path(*entity.parent);
+    return get_top_entity(*entity.parent);
 }
 
 static void add_annotation_to_datanode(const Entity & entity, path::DataNode & data_node)

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -444,7 +444,7 @@ void ydk::path::DataNodeImpl::add_annotation(const ydk::path::Annotation& an)
     }
 
     std::string name { an.m_ns + ":" + an.m_name };
-    YLOG_TRACE("Adding annotation '{}' = {} to {}", name, an.m_val, m_node->schema->name);
+    YLOG_TRACE("Adding annotation '{} = {}' to {}", name, an.m_val, m_node->schema->name);
 
     struct lyd_attr* attr = lyd_insert_attr(m_node, nullptr, name.c_str(), an.m_val.c_str());
 

--- a/sdk/cpp/core/src/path/path.cpp
+++ b/sdk/cpp/core/src/path/path.cpp
@@ -84,7 +84,7 @@ ydk::path::ValidationService::validate(const ydk::path::DataNode & dn, ydk::Vali
     int ly_option = 0;
     switch(option) {
         case ydk::ValidationService::Option::DATASTORE:
-            option_str="DATATSTORE";
+            option_str="DATASTORE";
             ly_option = LYD_OPT_CONFIG;
             break;
         case ydk::ValidationService::Option::EDIT_CONFIG:

--- a/sdk/cpp/core/src/path/repository.cpp
+++ b/sdk/cpp/core/src/path/repository.cpp
@@ -139,7 +139,7 @@ namespace ydk {
             }
         }
 
-        char* get_enlarged_data(const std::string & buffer)
+        char* get_enlarged_data(const std::string & buffer, const std::string & model_name)
         {
         	char *enlarged_data = nullptr;
 			/* enlarge data by 2 bytes for flex */
@@ -147,6 +147,7 @@ namespace ydk {
 			auto len = std::strlen(data);
 			enlarged_data = static_cast<char*>(std::malloc((len + 2) * sizeof *enlarged_data));
 			if (!enlarged_data) {
+			    YLOG_ERROR("Could not get model: {}", model_name);
 				throw(std::bad_alloc{});
 			}
 			memcpy(enlarged_data, data, len);
@@ -198,7 +199,7 @@ namespace ydk {
 
                         yang_file.close();
 
-                        return get_enlarged_data(model_data);
+                        return get_enlarged_data(model_data, yang_file_path);
                     } else {
                         YLOG_ERROR("Cannot open file {}", yang_file_path);
                         throw(YCPPIllegalStateError("Cannot open file"));
@@ -222,7 +223,7 @@ namespace ydk {
                     if(!model_data.empty()){
 
                         sink_to_file(yang_file_path, model_data);
-                        return get_enlarged_data(model_data);
+                        return get_enlarged_data(model_data, yang_file_path);
                     } else {
                         YLOG_TRACE("Cannot find model with module_name: {} module_rev: {}", module_name, (module_rev !=nullptr ? module_rev : ""));
 //                        throw(YCPPIllegalStateError{"Cannot find model"});
@@ -258,6 +259,7 @@ ydk::path::Repository::create_root_schema(const std::vector<path::Capability> & 
     struct ly_ctx* ctx = ly_ctx_new(path.c_str());
 
     if(!ctx) {
+        YLOG_ERROR("Could not create repository in: {}", path);
         throw(std::bad_alloc{});
     }
 

--- a/sdk/cpp/core/src/ydk_operation.cpp
+++ b/sdk/cpp/core/src/ydk_operation.cpp
@@ -1,5 +1,5 @@
 //
-// @file netconf_edit_operations.cpp
+// @file ydk_operation.cpp
 // @brief The main ydk public header.
 //
 // YANG Development Kit

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -182,10 +182,6 @@ TEST_CASE("bits")
 
 	auto & runner = schema.create("ydktest-sanity:runner", "");
 
-	//get the root
-	std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
-	REQUIRE( data_root != nullptr );
-
 	auto & ysanity = runner.create("ytypes/built-in-t/bits-value", "disable-nagle");
 
 	ydk::path::CodecService s{};
@@ -208,10 +204,6 @@ TEST_CASE("core_validate")
     ydk::path::RootSchemaNode& schema = sp.get_root_schema();
 
     auto & runner = schema.create("ietf-netconf:validate", "");
-
-    //get the root
-    std::shared_ptr<const ydk::path::DataNode> data_root{&runner.root()};
-    REQUIRE( data_root != nullptr );
 
     auto & ysanity = runner.create("source/candidate", "");
 

--- a/sdk/cpp/tests/test_crud.cpp
+++ b/sdk/cpp/tests/test_crud.cpp
@@ -168,3 +168,32 @@ TEST_CASE("bgp_read_create")
 	reply = crud.update(provider, *bgp_read_ptr);
 	REQUIRE(reply);
 }
+
+
+TEST_CASE("bgp_read_non_top")
+{
+	ydk::path::Repository repo{TEST_HOME};
+	NetconfServiceProvider provider{repo, "127.0.0.1", "admin", "admin", 12022};
+	CrudService crud{};
+	auto bgp_set = make_unique<openconfig_bgp::Bgp>();
+	bgp_set->global->config->as = 65001;
+	bgp_set->global->config->router_id = "1.2.3.4";
+        auto d = make_unique<openconfig_bgp::Bgp::Neighbors::Neighbor>();
+        d->neighbor_address = "1.2.3.4";
+        d->config->neighbor_address = "1.2.3.4";
+        bgp_set->neighbors->neighbor.push_back(move(d));
+        auto q = make_unique<openconfig_bgp::Bgp::Neighbors::Neighbor>();
+        q->neighbor_address = "1.2.3.5";
+        q->config->neighbor_address = "1.2.3.5";
+        bgp_set->neighbors->neighbor.push_back(move(q));
+	bool reply = crud.create(provider, *bgp_set);
+
+	REQUIRE(reply);
+
+	auto bgp_filter = make_unique<openconfig_bgp::Bgp>();
+	auto bgp_read = crud.read_config(provider, *(bgp_filter->neighbors));
+	REQUIRE(bgp_read!=nullptr);
+	openconfig_bgp::Bgp * bgp_read_ptr = dynamic_cast<openconfig_bgp::Bgp*>(bgp_read.get());
+	REQUIRE(bgp_read_ptr!=nullptr);
+
+}

--- a/sdk/cpp/tests/test_sanity_codec.cpp
+++ b/sdk/cpp/tests/test_sanity_codec.cpp
@@ -34,6 +34,7 @@ using namespace ydk;
 
 std::string XML_OC_PATTERN_PAYLOAD = R"(<oc-A xmlns="http://cisco.com/ns/yang/oc-pattern">
   <a>Hello</a>
+<B><b>Hello</b></B>
 </oc-A>
 )";
 
@@ -299,10 +300,19 @@ TEST_CASE("multiple_encode")
 TEST_CASE("test_oc_pattern")
 {
 
-    CodecServiceProvider codec_provider{EncodingFormat::XML};
+    CodecServiceProvider codec_provider{EncodingFormat::JSON};
     CodecService codec_service{};
 
-    auto entity = codec_service.decode(codec_provider, XML_OC_PATTERN_PAYLOAD, make_unique<oc_pattern::OcA>());
+    auto entity = codec_service.decode(codec_provider, "{\n"
+            "  \"oc-pattern:oc-A\": [\n"
+            "    {\n"
+            "      \"a\": \"Hello\",\n"
+            "      \"B\": {\n"
+            "        \"b\": \"Hello\"\n"
+            "      }\n"
+            "    }\n"
+            "  ]\n"
+            "}", make_unique<oc_pattern::OcA>());
 
     oc_pattern::OcA * entity_ptr = dynamic_cast<oc_pattern::OcA*>(entity.get());
     CHECK(entity_ptr->a.get() == "Hello");

--- a/sdk/cpp/tests/test_sanity_levels.cpp
+++ b/sdk/cpp/tests/test_sanity_levels.cpp
@@ -215,7 +215,7 @@ TEST_CASE("onelist")
     e_2->parent = r_1->one_list.get();
 	r_1->one_list->ldata.push_back(move(e_2));
 
-	reply = crud.create(provider, *r_1);
+	reply = crud.create(provider, *(r_1->one_list));
 	REQUIRE(reply);
 	auto r_read = crud.read(provider, *r_2);
 	REQUIRE(r_read != nullptr);

--- a/sdk/cpp/tests/test_sanity_types.cpp
+++ b/sdk/cpp/tests/test_sanity_types.cpp
@@ -626,3 +626,32 @@ TEST_CASE("test_types_bits_list")
 //	ydktest_sanity::Runner * r_2 = dynamic_cast<ydktest_sanity::Runner*>(r_read.get());
 //	REQUIRE(r_1->ytypes->built_in_t->bits_llist == r_2->ytypes->built_in_t->bits_llist);
 }
+
+TEST_CASE("string_leaflist")
+{
+    ydk::path::Repository repo{TEST_HOME};
+    NetconfServiceProvider provider{repo, "127.0.0.1", "admin", "admin", 12022};
+    CrudService crud{};
+
+    //DELETE
+    auto r_1 = make_unique<ydktest_sanity::Runner>();
+    bool reply = crud.delete_(provider, *r_1);
+    REQUIRE(reply);
+
+    //CREATE
+    r_1->ytypes->built_in_t->llstring.append("0");
+    r_1->ytypes->built_in_t->llstring.append("1");
+    r_1->ytypes->built_in_t->llstring.append("2");
+    r_1->ytypes->built_in_t->llstring.append("3");
+    r_1->ytypes->built_in_t->llstring.append("4");
+    r_1->ytypes->built_in_t->llstring.append("5");
+    reply = crud.create(provider, *r_1);
+    REQUIRE(reply);
+
+    //READ
+    auto filter = make_unique<ydktest_sanity::Runner>();
+    auto r_read = crud.read(provider, *filter);
+    REQUIRE(r_read!=nullptr);
+    ydktest_sanity::Runner * r_2 = dynamic_cast<ydktest_sanity::Runner*>(r_read.get());
+    REQUIRE(r_1->ytypes->built_in_t->enum_llist == r_2->ytypes->built_in_t->enum_llist);
+}

--- a/sdk/cpp/tests/testsanityvalidationtest.cpp
+++ b/sdk/cpp/tests/testsanityvalidationtest.cpp
@@ -43,7 +43,7 @@ TEST_CASE("validation_int8 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.number8 = static_cast<int8_t>(0);
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -61,7 +61,7 @@ TEST_CASE("validation_int16 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.number16 = static_cast<int16_t>(126);
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -78,7 +78,7 @@ TEST_CASE("validation_int32 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.number32 = 200000;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -95,7 +95,7 @@ TEST_CASE("validation_int64 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.number64 = -922337203685477580LL;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -112,7 +112,7 @@ TEST_CASE("validation_uint8 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.u_number8 =  static_cast<uint8_t>(0);
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -129,7 +129,7 @@ TEST_CASE("validation_uint16 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.u_number16 = static_cast<uint16_t>(65535);
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -147,7 +147,7 @@ TEST_CASE("validation_uint32 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.u_number32 = static_cast<uint32_t>(5927);
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 }
@@ -164,7 +164,7 @@ TEST_CASE("validation_uint64 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.u_number64 = 18446744073709551615ULL;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 }
@@ -184,7 +184,7 @@ TEST_CASE("bits ")
     auto r = builtInT.get_entity_path(nullptr);
     INFO(r.path);
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 }
@@ -200,7 +200,7 @@ TEST_CASE("validation_decimal64 ")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.deci64 = ydk::Decimal64("3.12");
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 }
@@ -216,7 +216,7 @@ TEST_CASE("validation_string")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.name = "name_str";
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -235,7 +235,7 @@ TEST_CASE("validation_empty")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.emptee = empty;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -252,7 +252,7 @@ TEST_CASE("validation_boolean")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.bool_value = true;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 }
@@ -271,7 +271,7 @@ TEST_CASE("validation_embedded_enum")
 
     builtInT.embeded_enum = ydk::ydktest_sanity::Runner::Ytypes::BuiltInT::EmbededEnumEnum::seven;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -291,7 +291,7 @@ TEST_CASE("validation_enum")
 
     builtInT.enum_value = ydk::ydktest_sanity::YdkEnumTestEnum::none;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -311,7 +311,7 @@ TEST_CASE("validation_union")
 
     builtInT.younion = ydk::ydktest_sanity::YdkEnumTestEnum::none;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -331,7 +331,7 @@ TEST_CASE("validation_union_enum")
 
     builtInT.enum_int_value = ydk::ydktest_sanity::YdkEnumIntTestEnum::any;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -348,7 +348,7 @@ TEST_CASE("validation_union_int")
     ydk::ydktest_sanity::Runner::Ytypes::BuiltInT builtInT{};
     builtInT.enum_int_value = 2;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -368,7 +368,7 @@ TEST_CASE("test_v_union_leaflist")
     builtInT.llunion.append( static_cast<uint16_t>(1));
     builtInT.llunion.append( static_cast<uint16_t>(2));
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -388,7 +388,7 @@ TEST_CASE("test_v_enum_leaflist")
     builtInT.enum_llist.append(ydk::ydktest_sanity::YdkEnumTestEnum::local);
     builtInT.enum_llist.append(ydk::ydktest_sanity::YdkEnumTestEnum::remote);
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -407,7 +407,7 @@ TEST_CASE("test_v_identity_leaflist")
     builtInT.identity_llist.append(ydk::ydktest_sanity::ChildIdentityIdentity{});
     builtInT.identity_llist.append(ydk::ydktest_sanity::ChildChildIdentityIdentity{});
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -427,7 +427,7 @@ TEST_CASE("test_v_union_complex_list")
 
     builtInT.younion_list.append("123:45");
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 
@@ -447,7 +447,7 @@ TEST_CASE("test_v_identityref")
     auto identity = ydk::ydktest_sanity::ChildChildIdentityIdentity{};
     builtInT.identity_ref_value = identity;
 
-    validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG);
+    CHECK_NOTHROW(validation_service.validate(sp, builtInT, ydk::ValidationService::Option::EDIT_CONFIG));
 
 
 

--- a/sdk/python/core/ydk/types.py
+++ b/sdk/python/core/ydk/types.py
@@ -316,7 +316,8 @@ class YLeafList(YList):
 
     def append(self, item):
         if item in self:
-            raise YPYModelError("{} already in list".format(item))
+            index = self.index(item)
+            raise YPYModelError("Value {} already in leaf-list: {}".format(item, self[index].name))
         lst_item = YListItem(item, self.parent, self.name)
         super(YLeafList, self).append(lst_item)
 
@@ -339,7 +340,8 @@ class YLeafList(YList):
 
     def insert(self, key, item):
         if item in self:
-            raise YPYModelError("{} already in list".format(item))
+            index = self.index(item)
+            raise YPYModelError("Value {} already in leaf-list: {}".format(item, self[index].name))
         lst_item = YListItem(item, self.parent, self.name)
         super(YLeafList, self).insert(key, lst_item)
 
@@ -349,7 +351,7 @@ class YLeafList(YList):
             if i.item == item:
                 return idx
             idx += 1
-        raise ValueError("{} is not in list".format(item))
+        raise ValueError("{} is not in leaf-list".format(item))
 
     def count(self, item):
         cnt = 0

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -284,7 +284,13 @@ function cpp_sanity_core_test {
 
     init_confd $YDKGEN_HOME/sdk/cpp/core/tests/confd/ydktest
     cd $YDKGEN_HOME/sdk/cpp/core/build
-    run_exec_test make test
+    make test
+    local status=$?
+    if [ $status -ne 0 ]; then
+    # If the tests fail, try to run them in verbose to get more details for  # debug
+        ./tests/ydk_core_test -s
+        exit $status
+    fi
     cd $YDKGEN_HOME
 }
 

--- a/ydkgen/printer/doc/doc_printer.py
+++ b/ydkgen/printer/doc/doc_printer.py
@@ -59,7 +59,7 @@ class DocPrinter(object):
     def print_table_of_contents(self, packages, bundle_name, bundle_version):
         self.lines = []
         title = '{0} bundle API'.format(bundle_name)
-        description = '\nModel API documentation for the {0} bundle. Version: {1}.\n'.format(bundle_name, bundle_version)
+        description = '\nModel API documentation for the {0} bundle.\n Version: **{1}**.\n'.format(bundle_name, bundle_version)
         self._print_title(title)
         self._append(description)
         self._print_toctree(packages, is_package=True)


### PR DESCRIPTION
 * Update cpp codec service decode signature
 * Print bundle version in bold in documentation
 * Add more details for duplicate leaf-list in legacy ydk-py (#398)
 * Yet to add support for read filter (setting leaf with no value in read  filter)