### PR TITLE
Correct message handling in various exception raises

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -31,6 +31,7 @@ import re
 
 from git import Repo
 from ydkgen import YdkGenerator
+from ydkgen.common import YdkGenException
 
 
 logger = logging.getLogger('ydkgen')
@@ -288,23 +289,29 @@ if __name__ == '__main__':
     elif options.python:
         language = 'python'
 
-    if options.bundle:
-        output_directory = (YdkGenerator(
-                            output_directory,
-                            ydk_root,
-                            options.groupings_as_class,
-                            options.gentests,
-                            language,
-                            'bundle').generate(options.bundle))
+    try:
+        if options.bundle:
+            output_directory = (YdkGenerator(
+                                output_directory,
+                                ydk_root,
+                                options.groupings_as_class,
+                                options.gentests,
+                                language,
+                                'bundle').generate(options.bundle))
 
-    if options.core:
-        output_directory = (YdkGenerator(
-                            output_directory,
-                            ydk_root,
-                            options.groupings_as_class,
-                            options.gentests,
-                            language,
-                            'core').generate(options.core))
+        if options.core:
+            output_directory = (YdkGenerator(
+                                output_directory,
+                                ydk_root,
+                                options.groupings_as_class,
+                                options.gentests,
+                                language,
+                                'core').generate(options.core))
+    except YdkGenException as e:
+        print('Error(s) occurred in YdkGenerator()!')
+        if not options.verbose:
+            print(e.msg)
+        sys.exit(1)
 
     if options.gendoc:
         generate_documentations(output_directory, ydk_root, language, options.bundle, options.core)

--- a/sdk/python/core/ydk/providers/codec_provider.py
+++ b/sdk/python/core/ydk/providers/codec_provider.py
@@ -39,7 +39,7 @@ class CodecServiceProvider(ServiceProvider):
 
     def __init__(self, **kwargs):
         if(len(kwargs) == 0):
-            raise YPYServiceProviderError('Codec type is required')
+            raise YPYServiceProviderError(error_msg='Codec type is required')
 
         codec_type = ''
         for key, val in kwargs.items():
@@ -50,7 +50,7 @@ class CodecServiceProvider(ServiceProvider):
             self.encoder = XmlEncoder()
             self.decoder = XmlDecoder()
         else:
-            raise YPYServiceProviderError('Codec type "{0}" not yet supported'.format(codec_type))
+            raise YPYServiceProviderError(error_msg='Codec type "{0}" not yet supported'.format(codec_type))
         self.logger = logging.getLogger(__name__)
 
     def _encode(self, entity):

--- a/sdk/python/core/ydk/services/crud_service.py
+++ b/sdk/python/core/ydk/services/crud_service.py
@@ -173,11 +173,13 @@ class CRUDService(Service):
     def _perform_read_filter_check(self, read_filter):
         if read_filter is None:
             self.service_logger.error('Passed in a None filter')
-            raise YPYServiceError('Filter cannot be None')
+            err_msg = "'filter' cannot be None"
+            raise YPYServiceError(error_msg=err_msg)
 
         if not isinstance(read_filter, YList) and not hasattr(read_filter, '_meta_info'):
-            self.service_logger.error('Illegal filter type passed in for read')
-            raise YPYServiceError('Illegal filter')
+            err_msg = "Illegal 'filter' type passed in for read"
+            self.service_logger.error(err_msg)
+            raise YPYServiceError(error_msg=err_msg)
 
     def _entity_exists(self, provider, entity):
         if None in (provider, entity):
@@ -191,8 +193,9 @@ class CRUDService(Service):
         )
 
         if not read_entity._has_data():
-            self.service_logger.error('Entity does not exist on remote server. Cannot perform update operations.')
-            raise YPYServiceError('Entity does not exist on remote server. Cannot perform update operation.')
+            err_msg = "'entity' does not exist on remote server - cannot perform update operation"
+            self.service_logger.error(err_msg)
+            raise YPYServiceError(error_msg=err_msg)
 
         return True
 

--- a/sdk/python/core/ydk/services/ietf_netconf.py
+++ b/sdk/python/core/ydk/services/ietf_netconf.py
@@ -445,7 +445,7 @@ class GetConfigRpc(object):
             def is_config(self):
                 ''' Returns True if this instance represents config data else returns False '''
                 if self.parent is None:
-                    raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                    raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
                 return self.parent.is_config()
 
             def _has_data(self):
@@ -475,7 +475,7 @@ class GetConfigRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -526,7 +526,7 @@ class GetConfigRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -783,7 +783,7 @@ class EditConfigRpc(object):
             def is_config(self):
                 ''' Returns True if this instance represents config data else returns False '''
                 if self.parent is None:
-                    raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                    raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
                 return self.parent.is_config()
 
             def _has_data(self):
@@ -810,7 +810,7 @@ class EditConfigRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -969,7 +969,7 @@ class CopyConfigRpc(object):
             def is_config(self):
                 ''' Returns True if this instance represents config data else returns False '''
                 if self.parent is None:
-                    raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                    raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
                 return self.parent.is_config()
 
             def _has_data(self):
@@ -1047,7 +1047,7 @@ class CopyConfigRpc(object):
             def is_config(self):
                 ''' Returns True if this instance represents config data else returns False '''
                 if self.parent is None:
-                    raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                    raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
                 return self.parent.is_config()
 
             def _has_data(self):
@@ -1083,7 +1083,7 @@ class CopyConfigRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -1207,7 +1207,7 @@ class DeleteConfigRpc(object):
             def is_config(self):
                 ''' Returns True if this instance represents config data else returns False '''
                 if self.parent is None:
-                    raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                    raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
                 return self.parent.is_config()
 
             def _has_data(self):
@@ -1234,7 +1234,7 @@ class DeleteConfigRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -1359,7 +1359,7 @@ class LockRpc(object):
             def is_config(self):
                 ''' Returns True if this instance represents config data else returns False '''
                 if self.parent is None:
-                    raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                    raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
                 return self.parent.is_config()
 
             def _has_data(self):
@@ -1389,7 +1389,7 @@ class LockRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -1514,7 +1514,7 @@ class UnlockRpc(object):
             def is_config(self):
                 ''' Returns True if this instance represents config data else returns False '''
                 if self.parent is None:
-                    raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                    raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
                 return self.parent.is_config()
 
             def _has_data(self):
@@ -1544,7 +1544,7 @@ class UnlockRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -1647,7 +1647,7 @@ class GetRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -1695,7 +1695,7 @@ class GetRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -1827,7 +1827,7 @@ class KillSessionRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -1938,7 +1938,7 @@ class CommitRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -2076,7 +2076,7 @@ class CancelCommitRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):
@@ -2212,7 +2212,7 @@ class ValidateRpc(object):
             def is_config(self):
                 ''' Returns True if this instance represents config data else returns False '''
                 if self.parent is None:
-                    raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                    raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
                 return self.parent.is_config()
 
             def _has_data(self):
@@ -2248,7 +2248,7 @@ class ValidateRpc(object):
         def is_config(self):
             ''' Returns True if this instance represents config data else returns False '''
             if self.parent is None:
-                raise YPYError('Parent reference is needed to determine if entity has configuration data')
+                raise YPYError(error_msg='Parent reference is needed to determine if entity has configuration data')
             return self.parent.is_config()
 
         def _has_data(self):


### PR DESCRIPTION
Some exception raises were passing the message as the first positional instead of by name. That would of caused the message to be interpreted as an error_code