### PR TITLE
crud update fix

### DIFF
--- a/sdk/python/core/ydk/services/crud_service.py
+++ b/sdk/python/core/ydk/services/crud_service.py
@@ -29,6 +29,7 @@ from .service import Service
 from .meta_service import MetaService
 import logging
 import importlib
+import operator
 
 
 class CRUDService(Service):

--- a/sdk/python/core/ydk/services/crud_service.py
+++ b/sdk/python/core/ydk/services/crud_service.py
@@ -206,7 +206,7 @@ class CRUDService(Service):
             raise YPYServiceError(error_msg=err_msg)
 
         module = importlib.import_module(entity._meta_info().pmodule_name)
-        update_filter = getattr(module, entity._meta_info().name)()
+        update_filter = operator.attrgetter(entity._meta_info().name)(module)()
 
         # copy over the keys
         for key_member in entity._meta_info().key_members():


### PR DESCRIPTION
The update operation in crud_service.py has a _create_update_entity_filter function, which tries to read the entity in the module, but the update_filter fails to fetch the nested class instance, because of the behavior of python getattr function, which does not support consecutive attribute retrievals.  
The fix for this issue can be to use the operator.attrgetattr() python function instead. 

