### PR TITLE
Update ydk.providers.rst

### DIFF
--- a/sdk/python/core/docsgen/ydk.providers.rst
+++ b/sdk/python/core/docsgen/ydk.providers.rst
@@ -15,11 +15,11 @@ uses ncclient (a Netconf client library) to provide CRUD services.
 	
 	Initialization parameter of NetconfServiceProvider
 	
-	:param address: The address of the netconf server
+	:param address: The address of the netconf server(ignored if protocol is onbox)
 	:param port: The port to use default is 830
 	:param username: The name of the user
 	:param password: The password to use
-	:param protocol: One of either ssh or tcp
+	:param protocol: One of either ssh or tcp or onbox(use pipe to communicate with netconf agent)
 	:timeout: Default to 45
 	
 	.. py:method:: close()


### PR DESCRIPTION

Added descriptions for onbox support, which runs on routers (including virtual routers such as enxr or physical routers such as asr9k) without requiring  ssh set up