### PR TITLE
Documentation in README.md for adhoc bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,19 @@ Note that the below process could take a few hours due to the size of the `cisco
 ```
 Pre-generated documentation for [ydk-py](http://ydk.cisco.com/py/docs/) and [ydk-cpp](http://ydk.cisco.com/cpp/docs/) are available.
 
+# Generating an "Adhoc" YDK-Py Bundle
+
+The ability to generate an adhoc bundle directly from the command line and without creating a bundle file can be done something like this:
+
+```
+$ ./generate.py --adhoc-bundle-name test --adhoc-bundle \
+    /opt/git-repos/clean-yang/vendor/cisco/xr/621/Cisco-IOS-XR-ipv4-bgp-oper*.yang \
+    /opt/git-repos/clean-yang/vendor/cisco/xr/621/Cisco-IOS-XR-types.yang
+    /opt/git-repos/clean-yang/vendor/cisco/xr/621/Cisco-IOS-XR-ipv4-bgp-datatypes.yang
+```
+
+When run in this way, we will generate a bundle that only contains tje files specified with the `--adhoc-bundle` option, creating a pip package name by the `--adhoc-bundle-name`, with a version `0.1.0` and a dependency on the base IETF bundle. Note that **all** dependencies for the bundle must be listed, and as the expectation is that this option will typically be used for generating point YDK-Py bundles for specific testing, the `--verbose` option is automatically enabled to quickly and easily let a user see if dependencies have been satisfied.
+
 # Notes
 
 ## Python version

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ YANG Development Kit (Generator)
   - [Third step: Generate & install your bundle](#third-step-generate--install-your-bundle)
   - [Fourth step: Writing your first app](#fourth-step-writing-your-first-app)
   - [Documentation](#documentation)
+- [Generating an "Adhoc" YDK-Py Bundle](#generating-an-adhoc-ydk-py-bundle)
 - [Notes](#notes)
   - [Python version](#python-version)
   - [Directory structure](#directory-structure)
@@ -32,6 +33,8 @@ YANG Development Kit (Generator)
 - [Running Unit Tests](#running-unit-tests)
   - [Python](#python)
   - [C++](#c)
+- [Support](#support)
+- [Release Notes](#release-notes)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
I accidentally pushed a couple of extra options for generating adhoc bundles (as has been discussed) directly to the main repo. This PR is for the extra README content detailing usage.
