### PR TITLE
Path api refactor

### DIFF
--- a/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
@@ -98,7 +98,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
 
         :return: Pointer to the parent of this :cpp:class:`DataNode<DataNode>` or ``nullptr`` if None exist.
 
-    .. cpp:function:: virtual std::vector<std::shared_ptr<DataNode>> children() const
+    .. cpp:function:: virtual std::vector<std::shared_ptr<DataNode>> get_children() const
 
         :return: Pointer to the children of this :cpp:class:`DataNode<DataNode>`.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
@@ -102,7 +102,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
 
         :return: Pointer to the children of this :cpp:class:`DataNode<DataNode>`.
 
-    .. cpp:function:: virtual const DataNode& root() const
+    .. cpp:function:: virtual const DataNode& get_root() const
 
         :return: Pointer to the root :cpp:class:`DataNode<DataNode>` of this tree.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
@@ -24,7 +24,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
 
         :return: :cpp:class:`SchemaNode<SchemaNode>` associated with this :cpp:class:`DataNode<DataNode>`.
 
-    .. cpp:function:: virtual std::string path() const
+    .. cpp:function:: virtual std::string get_path() const
 
         Returns the path expression representing this Node in in the NodeTree.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
@@ -18,7 +18,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
 
             A :cpp:class:`DataNode<DataNode>` represents a containment hierarchy. So invocation of the destructor will lead to the children of this node being destroyed.
 
-    .. cpp:function:: virtual const SchemaNode& schema() const
+    .. cpp:function:: virtual const SchemaNode& get_schema_node() const
 
         Returns the :cpp:class:`SchemaNode<SchemaNode>` associated with this :cpp:class:`DataNode<DataNode>`.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
@@ -94,7 +94,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
         :param path: The path expression.
         :return: Vector of :cpp:class:`DataNode<DataNode>` that satisfy the path expression supplied.
 
-    .. cpp:function:: virtual DataNode* parent() const
+    .. cpp:function:: virtual DataNode* get_parent() const
 
         :return: Pointer to the parent of this :cpp:class:`DataNode<DataNode>` or ``nullptr`` if None exist.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
@@ -69,7 +69,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
         :raises: :cpp:class:`YCPPInvalidArgumentError<YCPPInvalidArgumentError>` In case the argument is invalid.
         :raises: :cpp:class:`YCPPPathError<YCPPPathError>` In case the path is invalid.
 
-    .. cpp:function:: virtual void set(const std::string& value)
+    .. cpp:function:: virtual void set_value(const std::string& value)
 
         Set the value of this :cpp:class:`DataNode<DataNode>`.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
@@ -81,7 +81,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
         :param value: The value to set. This should be the string representation of the YANG type.
         :raises: :cpp:class:`YCPPInvalidArgumentError<YCPPInvalidArgumentError>` if the :cpp:class:`DataNode<DataNode>`'s value cannot be set (for example it represents a container)
 
-    .. cpp:function:: virtual std::string get() const
+    .. cpp:function:: virtual std::string get_value() const
 
         Returns a copy of the value of this :cpp:class:`DataNode<DataNode>`.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_data.rst
@@ -30,7 +30,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
 
         :return: ``std::string`` representing the path to this Node.
 
-    .. cpp:function:: virtual DataNode& create(const std::string& path)
+    .. cpp:function:: virtual DataNode& create_datanode(const std::string& path)
 
         Creates a :cpp:class:`DataNode<DataNode>` corresponding to the path and set its value.
 
@@ -50,7 +50,7 @@ Class represents the :cpp:class:`DataNode<DataNode>`.
         :raises: :cpp:class:`YCPPInvalidArgumentError<YCPPInvalidArgumentError>` In case the argument is invalid.
         :raises: :cpp:class:`YCPPPathError<YCPPPathError>` In case the path is invalid.
 
-    .. cpp:function:: virtual DataNode& create(const std::string& path, const std::string& value)
+    .. cpp:function:: virtual DataNode& create_datanode(const std::string& path, const std::string& value)
 
         Create a :cpp:class:`DataNode<DataNode>` corresponding to the path and set its value.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
@@ -31,7 +31,7 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
         :raises: :cpp:class:`YCPPPathError<YCPPPathError>` if the path expression in invalid, See error code for details.
         :raises: :cpp:class:`YCPPInvalidArgumentError<YCPPInvalidArgumentError>` if the argument is invalid.
 
-    .. cpp:function:: virtual SchemaNode* parent() const noexcept
+    .. cpp:function:: virtual SchemaNode* get_parent() const noexcept
 
         Get the parent node of this :cpp:class:`SchemaNode<SchemaNode>` in the tree.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
@@ -14,7 +14,7 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
 
         Destructor for the :cpp:class:`RootSchemaNode<RootSchemaNode>`
 
-    .. cpp:function:: std::string path() const
+    .. cpp:function:: std::string get_path() const
 
         Get the path expression representing this Node in in the NodeTree.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
@@ -84,7 +84,7 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
         :raises: :cpp:class:`YCPPInvalidArgumentError<YCPPInvalidArgumentError>` In case the argument is invalid.
         :raises: :cpp:class:`YCPPPathError<YCPPPathError>` In case the path is invalid.
 
-    .. cpp:function:: virtual Statement statement() const
+    .. cpp:function:: virtual Statement get_statement() const
 
         Return the :cpp:class:`Statement<Statement>` representing this :cpp:class:`SchemaNode<SchemaNode>`.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
@@ -100,7 +100,7 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
 
             :return: Vector of :cpp:class:`Statement` that represent keys.
 
-    .. cpp:function:: virtual Rpc* rpc(const std::string& path) const
+    .. cpp:function:: virtual Rpc* create_rpc(const std::string& path) const
 
         Create an :cpp:class:`Rpc<Rpc>` instance.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
@@ -94,6 +94,12 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
 
         :return: An empty statement.
 
+    .. cpp:function:: virtual std::vector<Statement> get_keys() const
+
+            Returns vector of YANG statement corresponding the the keys.
+
+            :return: Vector of :cpp:class:`Statement` that represent keys.
+
     .. cpp:function:: virtual Rpc* rpc(const std::string& path) const
 
         Create an :cpp:class:`Rpc<Rpc>` instance.

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
@@ -43,7 +43,7 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
 
         :return: The children of this node.
 
-    .. cpp:function:: virtual const SchemaNode* root() const noexcept
+    .. cpp:function:: virtual const SchemaNode* get_root() const noexcept
 
         Get the root of NodeTree this node is part of.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
@@ -37,7 +37,7 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
 
         :return: Pointer to the parent node or ``nullptr`` in case this is the root.
 
-    .. cpp:function:: virtual std::vector<SchemaNode*> children() const
+    .. cpp:function:: virtual std::vector<SchemaNode*> get_children() const
 
         Get the children of this :cpp:class:`SchemaNode<SchemaNode>` in the NodeTree.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_rootschema.rst
@@ -49,7 +49,7 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
 
         :return: The pointer to the root.
 
-    .. cpp:function:: virtual DataNode* create(const std::string& path, const std::string& value) const
+    .. cpp:function:: virtual DataNode* create_datanode(const std::string& path, const std::string& value) const
 
         Create a :cpp:class:`DataNode<DataNode>` corresponding to the path and set its value.
 
@@ -67,7 +67,7 @@ Instances of this class represent the Root of the :cpp:class:`SchemaNode<SchemaN
         :raises: :cpp:class:`YCPPInvalidArgumentError<YCPPInvalidArgumentError>` In case the argument is invalid.
         :raises: :cpp:class:`YCPPPathError<YCPPPathError>` In case the path is invalid.
 
-    .. cpp:function:: virtual DataNode* create(const std::string& path, const std::string& value) const
+    .. cpp:function:: virtual DataNode* create_datanode(const std::string& path, const std::string& value) const
 
         Create a :cpp:class:`DataNode<DataNode>` corresponding to the path and set its value.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
@@ -47,7 +47,7 @@ Represents a Node in the SchemaTree.
 
         :return: ``SchemaNode*`` the children of this node.
 
-    .. cpp:function:: virtual std::vector<std::unique_ptr<SchemaNode>> & children() const
+    .. cpp:function:: virtual std::vector<std::unique_ptr<SchemaNode>> & get_children() const
 
         Returns the children of this :cpp:class:`SchemaNode <SchemaNode>` in the NodeTree.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
@@ -65,7 +65,7 @@ Represents a Node in the SchemaTree.
 
         :return: The pointer to the yang statement for this :cpp:class:`SchemaNode<SchemaNode>`
 
-    .. cpp:function:: virtual std::vector<Statement> keys() const
+    .. cpp:function:: virtual std::vector<Statement> get_keys() const
 
         Returns vector of YANG statement corresponding the the keys.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
@@ -53,7 +53,7 @@ Represents a Node in the SchemaTree.
 
         :return: Child schema nodes.
 
-    .. cpp:function:: virtual const SchemaNode& root() const noexcept
+    .. cpp:function:: virtual const SchemaNode& get_root() const noexcept
 
         Get the root of NodeTree this node is part of
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
@@ -41,7 +41,7 @@ Represents a Node in the SchemaTree.
         :raises: :cpp:class:`YCPPPathError<YCPPPathError>` if the path expression in invalid, see error code for details.
         :raises: :cpp:class:`YCPPInvalidArgumentError<YCPPInvalidArgumentError>` if the argument is invalid.
 
-    .. cpp:function:: virtual const SchemaNode* parent() const noexcept
+    .. cpp:function:: virtual const SchemaNode* get_parent() const noexcept
 
         Get the Parent Node of this SchemaNode in the tree.
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
@@ -59,7 +59,7 @@ Represents a Node in the SchemaTree.
 
         :return: The pointer to the root.
 
-    .. cpp:function:: virtual Statement statement() const
+    .. cpp:function:: virtual Statement get_statement() const
 
         Returns the YANG statement associated with this :cpp:class:`SchemaNode<SchemaNode>`
 

--- a/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
+++ b/sdk/cpp/core/docsgen/api/nodes/core_node_schema.rst
@@ -24,7 +24,7 @@ Represents a Node in the SchemaTree.
 
             A :cpp:class:`SchemaNode<SchemaNode>` represents a containment hierarchy. So invocation of the destructor will lead to the children of this node being destroyed.
 
-    .. cpp:function:: virtual std::string path() const
+    .. cpp:function:: virtual std::string get_path() const
 
         Get the path expression representing this Node in in the NodeTree.
 

--- a/sdk/cpp/core/docsgen/api/rpc.rst
+++ b/sdk/cpp/core/docsgen/api/rpc.rst
@@ -29,6 +29,6 @@ if any. The Callable takes as a parameter the :cpp:class:`ServiceProvider<Servic
 
         :return: Pointer to the input :cpp:class:`DataNode<DataNode>` or ``nullptr`` if the rpc does not have an input element in the schema.
 
-    .. cpp:function:: virtual SchemaNode& schema() const
+    .. cpp:function:: virtual SchemaNode& get_schema_node() const
 
         :return: Pointer to the :cpp:class:`SchemaNode<SchemaNode>` associated with this rpc.

--- a/sdk/cpp/core/docsgen/api/rpc.rst
+++ b/sdk/cpp/core/docsgen/api/rpc.rst
@@ -23,7 +23,7 @@ if any. The Callable takes as a parameter the :cpp:class:`ServiceProvider<Servic
         :param sp: The Service provider.
         :return: Pointer to the :cpp:class:`DataNode<DataNode>` or ``nullptr`` if none exists.
 
-    .. cpp:function:: virtual DataNode& input() const
+    .. cpp:function:: virtual DataNode& get_input_node() const
 
         Get the input data tree.
 

--- a/sdk/cpp/core/samples/bgp.cpp
+++ b/sdk/cpp/core/samples/bgp.cpp
@@ -17,7 +17,7 @@
 void print_paths(ydk::path::SchemaNode & sn)
 {
     std::cout << sn.path() << std::endl;
-    for(auto const& p : sn.children())
+    for(auto const& p : sn.get_children())
         print_paths(*p);
 }
 

--- a/sdk/cpp/core/samples/bgp.cpp
+++ b/sdk/cpp/core/samples/bgp.cpp
@@ -33,7 +33,7 @@ void test_bgp_create()
     auto & bgp = schema.create("openconfig-bgp:bgp", "");
 
     // get the root
-    // std::unique_ptr<const ydk::path::DataNode> data_root{bgp->root()};
+    // std::unique_ptr<const ydk::path::DataNode> data_root{bgp->get_root()};
 
     bgp.create("global/config/as", "65172");
 

--- a/sdk/cpp/core/samples/bgp.cpp
+++ b/sdk/cpp/core/samples/bgp.cpp
@@ -30,31 +30,31 @@ void test_bgp_create()
     ydk::path::RootSchemaNode& schema = sp.get_root_schema();
     print_paths(schema);
 
-    auto & bgp = schema.create("openconfig-bgp:bgp", "");
+    auto & bgp = schema.create_datanode("openconfig-bgp:bgp", "");
 
     // get the root
     // std::unique_ptr<const ydk::path::DataNode> data_root{bgp->get_root()};
 
-    bgp.create("global/config/as", "65172");
+    bgp.create_datanode("global/config/as", "65172");
 
 
-    auto & l3vpn_ipv4_unicast = bgp.create("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
-    l3vpn_ipv4_unicast.create("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    auto & l3vpn_ipv4_unicast = bgp.create_datanode("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    l3vpn_ipv4_unicast.create_datanode("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
 
 
     // set the enable flag
-    l3vpn_ipv4_unicast.create("config/enabled","true");
+    l3vpn_ipv4_unicast.create_datanode("config/enabled","true");
 
     // bgp/neighbors/neighbor
-    auto & neighbor = bgp.create("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
-    neighbor.create("config/neighbor-address", "172.16.255.2");
-    neighbor.create("config/peer-as","65172");
+    auto & neighbor = bgp.create_datanode("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
+    neighbor.create_datanode("config/neighbor-address", "172.16.255.2");
+    neighbor.create_datanode("config/peer-as","65172");
 
 
     // bgp/neighbors/neighbor/afi-safis/afi-safi
-    auto & neighbor_af = neighbor.create("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
-    neighbor_af.create("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
-    neighbor_af.create("config/enabled","true");
+    auto & neighbor_af = neighbor.create_datanode("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    neighbor_af.create_datanode("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    neighbor_af.create_datanode("config/enabled","true");
 
     ydk::path::Codec s {};
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, true);
@@ -91,7 +91,7 @@ void test_bgp_create()
 
     // TODO fix rpc
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
 
     // call create
     (*create_rpc)(sp);

--- a/sdk/cpp/core/samples/bgp.cpp
+++ b/sdk/cpp/core/samples/bgp.cpp
@@ -90,7 +90,7 @@ void test_bgp_create()
 
 
     // TODO fix rpc
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
 
     // call create

--- a/sdk/cpp/core/samples/bgp.cpp
+++ b/sdk/cpp/core/samples/bgp.cpp
@@ -16,7 +16,7 @@
 
 void print_paths(ydk::path::SchemaNode & sn)
 {
-    std::cout << sn.path() << std::endl;
+    std::cout << sn.get_path() << std::endl;
     for(auto const& p : sn.get_children())
         print_paths(*p);
 }

--- a/sdk/cpp/core/samples/bgp.cpp
+++ b/sdk/cpp/core/samples/bgp.cpp
@@ -91,7 +91,7 @@ void test_bgp_create()
 
     // TODO fix rpc
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
 
     // call create
     (*create_rpc)(sp);

--- a/sdk/cpp/core/src/codec_service.cpp
+++ b/sdk/cpp/core/src/codec_service.cpp
@@ -70,8 +70,8 @@ CodecService::encode(CodecServiceProvider & provider, Entity & entity, bool pret
     {
         path::DataNode& datanode = get_data_node_from_entity(entity, root_schema);
         const path::DataNode* dn = &datanode;
-        while(dn!= nullptr && dn->parent()!=nullptr)
-            dn = dn->parent();
+        while(dn!= nullptr && dn->get_parent()!=nullptr)
+            dn = dn->get_parent();
         path::Codec core_codec_service{};
         std::string result = core_codec_service.encode(*dn, provider.m_encoding, pretty);
         YLOG_INFO("Performing encode operation, resulting in {}", result);

--- a/sdk/cpp/core/src/codec_service.cpp
+++ b/sdk/cpp/core/src/codec_service.cpp
@@ -118,14 +118,14 @@ CodecService::decode(CodecServiceProvider & provider, const std::string & payloa
     path::Codec core_codec_service{};
     auto root_data_node = core_codec_service.decode(root_schema, payload, provider.m_encoding);
 
-    if (root_data_node->children().size() != 1)
+    if (root_data_node->get_children().size() != 1)
     {
         YLOG_ERROR(PAYLOAD_ERROR_MSG);
         throw(YCPPServiceProviderError(PAYLOAD_ERROR_MSG));
     }
     else
     {
-        for (auto data_node: root_data_node->children())
+        for (auto data_node: root_data_node->get_children())
         {
             get_entity_from_data_node(data_node.get(), entity);
             // Required for validation of decoded entity

--- a/sdk/cpp/core/src/crud_service.cpp
+++ b/sdk/cpp/core/src/crud_service.cpp
@@ -130,9 +130,9 @@ static shared_ptr<path::DataNode> execute_rpc(path::ServiceProvider & provider, 
 
     if(set_config_flag)
     {
-        ydk_rpc->input().create_datanode("only-config");
+        ydk_rpc->get_input_node().create_datanode("only-config");
     }
-    ydk_rpc->input().create_datanode(data_tag, data);
+    ydk_rpc->get_input_node().create_datanode(data_tag, data);
     return (*ydk_rpc)(provider);
 }
 

--- a/sdk/cpp/core/src/crud_service.cpp
+++ b/sdk/cpp/core/src/crud_service.cpp
@@ -141,8 +141,8 @@ static string get_config_data_payload(Entity & entity, path::ServiceProvider & p
     const ydk::path::DataNode& datanode = get_data_node_from_entity(entity, provider.get_root_schema());
 
     const path::DataNode* dn = &datanode;
-    while(dn!= nullptr && dn->parent()!=nullptr)
-        dn = dn->parent();
+    while(dn!= nullptr && dn->get_parent()!=nullptr)
+        dn = dn->get_parent();
     path::Codec codec{};
     YLOG_DEBUG("Encoding the subtree filter request using path API DataNode");
     string payload = codec.encode(*dn, provider.get_encoding(), false);

--- a/sdk/cpp/core/src/crud_service.cpp
+++ b/sdk/cpp/core/src/crud_service.cpp
@@ -90,7 +90,7 @@ shared_ptr<Entity> CrudService::read_datanode(Entity & filter, shared_ptr<path::
     if (read_data_node == nullptr)
         return {};
     shared_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
-    get_entity_from_data_node(read_data_node->children()[0].get(), top_entity);
+    get_entity_from_data_node(read_data_node->get_children()[0].get(), top_entity);
     return top_entity;
 }
 

--- a/sdk/cpp/core/src/crud_service.cpp
+++ b/sdk/cpp/core/src/crud_service.cpp
@@ -130,9 +130,9 @@ static shared_ptr<path::DataNode> execute_rpc(path::ServiceProvider & provider, 
 
     if(set_config_flag)
     {
-        ydk_rpc->input().create("only-config");
+        ydk_rpc->input().create_datanode("only-config");
     }
-    ydk_rpc->input().create(data_tag, data);
+    ydk_rpc->input().create_datanode(data_tag, data);
     return (*ydk_rpc)(provider);
 }
 

--- a/sdk/cpp/core/src/crud_service.cpp
+++ b/sdk/cpp/core/src/crud_service.cpp
@@ -117,7 +117,7 @@ static shared_ptr<path::DataNode> execute_rpc(path::ServiceProvider & provider, 
 //        validation.validate(provider, entity, ValidationService::Option::DATASTORE);
 //    }
     path::RootSchemaNode& root_schema = provider.get_root_schema();
-    shared_ptr<ydk::path::Rpc> ydk_rpc { root_schema.rpc(operation) };
+    shared_ptr<ydk::path::Rpc> ydk_rpc { root_schema.create_rpc(operation) };
     string data;
     if(data_tag == "filter" && provider.get_encoding() == EncodingFormat::XML)
     {

--- a/sdk/cpp/core/src/entity_data_node_walker.cpp
+++ b/sdk/cpp/core/src/entity_data_node_walker.cpp
@@ -57,7 +57,7 @@ static path::Annotation get_annotation(YFilter yfilter);
 path::DataNode& get_data_node_from_entity(Entity & entity, path::RootSchemaNode & root_schema)
 {
     EntityPath root_path = entity.get_entity_path(nullptr);
-    auto & root_data_node = root_schema.create(root_path.path);
+    auto & root_data_node = root_schema.create_datanode(root_path.path);
     if(is_set(entity.yfilter))
     {
         add_annotation_to_datanode(entity, root_data_node);
@@ -89,7 +89,7 @@ static void populate_data_node(Entity & entity, path::DataNode & parent_data_nod
     EntityPath path = entity.get_entity_path(entity.parent);
     path::DataNode* data_node = nullptr;
 
-    data_node = &parent_data_node.create(path.path);
+    data_node = &parent_data_node.create_datanode(path.path);
 
     if(is_set(entity.yfilter))
     {
@@ -112,7 +112,7 @@ static void populate_name_values(path::DataNode & data_node, EntityPath & path)
 
         if(leaf_data.is_set)
         {
-            result = &data_node.create(name_value.first, leaf_data.value);
+            result = &data_node.create_datanode(name_value.first, leaf_data.value);
             YLOG_DEBUG("Result: {}", (result?"success":"failure"));
 
             if(is_set(leaf_data.yfilter))

--- a/sdk/cpp/core/src/entity_data_node_walker.cpp
+++ b/sdk/cpp/core/src/entity_data_node_walker.cpp
@@ -169,8 +169,8 @@ void get_entity_from_data_node(path::DataNode * node, std::shared_ptr<Entity> en
         if(data_node_is_leaf(*child_data_node))
         {
             YLOG_DEBUG("Creating leaf {} of value '{}' in parent {}", child_name,
-                    child_data_node->get(), node->get_path());
-            entity->set_value(child_name, child_data_node->get());
+                    child_data_node->get_value(), node->get_path());
+            entity->set_value(child_name, child_data_node->get_value());
         }
         else
         {

--- a/sdk/cpp/core/src/entity_data_node_walker.cpp
+++ b/sdk/cpp/core/src/entity_data_node_walker.cpp
@@ -165,7 +165,7 @@ void get_entity_from_data_node(path::DataNode * node, std::shared_ptr<Entity> en
 
     for(auto & child_data_node:node->get_children())
     {
-        std::string child_name = child_data_node->schema().statement().arg;
+        std::string child_name = child_data_node->schema().get_statement().arg;
         if(data_node_is_leaf(*child_data_node))
         {
             YLOG_DEBUG("Creating leaf {} of value '{}' in parent {}", child_name,
@@ -197,13 +197,13 @@ void get_entity_from_data_node(path::DataNode * node, std::shared_ptr<Entity> en
 
 static bool data_node_is_leaf(path::DataNode & data_node)
 {
-    return (data_node.schema().statement().keyword == "leaf"
-            || data_node.schema().statement().keyword == "leaf-list");
+    return (data_node.schema().get_statement().keyword == "leaf"
+            || data_node.schema().get_statement().keyword == "leaf-list");
 }
 
 static bool data_node_is_list(path::DataNode & data_node)
 {
-    return (data_node.schema().statement().keyword == "list");
+    return (data_node.schema().get_statement().keyword == "list");
 }
 
 static string get_segment_path(const string & path)

--- a/sdk/cpp/core/src/entity_data_node_walker.cpp
+++ b/sdk/cpp/core/src/entity_data_node_walker.cpp
@@ -107,7 +107,7 @@ static void populate_name_values(path::DataNode & data_node, EntityPath & path)
     {
         path::DataNode* result = nullptr;
         LeafData leaf_data = name_value.second;
-        YLOG_DEBUG("Creating child {} of {} with value: '{}', is_set: {}", name_value.first, data_node.path(),
+        YLOG_DEBUG("Creating child {} of {} with value: '{}', is_set: {}", name_value.first, data_node.get_path(),
                 leaf_data.value, leaf_data.is_set);
 
         if(leaf_data.is_set)
@@ -169,16 +169,16 @@ void get_entity_from_data_node(path::DataNode * node, std::shared_ptr<Entity> en
         if(data_node_is_leaf(*child_data_node))
         {
             YLOG_DEBUG("Creating leaf {} of value '{}' in parent {}", child_name,
-                    child_data_node->get(), node->path());
+                    child_data_node->get(), node->get_path());
             entity->set_value(child_name, child_data_node->get());
         }
         else
         {
-            YLOG_DEBUG("Going into child {} in parent {}", child_name, node->path());
+            YLOG_DEBUG("Going into child {} in parent {}", child_name, node->get_path());
             std::shared_ptr<Entity> child_entity;
             if(data_node_is_list(*child_data_node))
             {
-                child_entity = entity->get_child_by_name(child_name, get_segment_path(child_data_node->path()));
+                child_entity = entity->get_child_by_name(child_name, get_segment_path(child_data_node->get_path()));
             }
             else
             {
@@ -188,7 +188,7 @@ void get_entity_from_data_node(path::DataNode * node, std::shared_ptr<Entity> en
 
             if(child_entity == nullptr)
             {
-                YLOG_ERROR("Couldn't fetch child entity {} in parent {}!", child_name, node->path());
+                YLOG_ERROR("Couldn't fetch child entity {} in parent {}!", child_name, node->get_path());
             }
             get_entity_from_data_node(child_data_node.get(), child_entity);
         }

--- a/sdk/cpp/core/src/entity_data_node_walker.cpp
+++ b/sdk/cpp/core/src/entity_data_node_walker.cpp
@@ -163,7 +163,7 @@ void get_entity_from_data_node(path::DataNode * node, std::shared_ptr<Entity> en
     if (entity == nullptr || node == nullptr)
         return;
 
-    for(auto & child_data_node:node->children())
+    for(auto & child_data_node:node->get_children())
     {
         std::string child_name = child_data_node->schema().statement().arg;
         if(data_node_is_leaf(*child_data_node))

--- a/sdk/cpp/core/src/entity_data_node_walker.cpp
+++ b/sdk/cpp/core/src/entity_data_node_walker.cpp
@@ -165,7 +165,7 @@ void get_entity_from_data_node(path::DataNode * node, std::shared_ptr<Entity> en
 
     for(auto & child_data_node:node->get_children())
     {
-        std::string child_name = child_data_node->schema().get_statement().arg;
+        std::string child_name = child_data_node->get_schema_node().get_statement().arg;
         if(data_node_is_leaf(*child_data_node))
         {
             YLOG_DEBUG("Creating leaf {} of value '{}' in parent {}", child_name,
@@ -197,13 +197,13 @@ void get_entity_from_data_node(path::DataNode * node, std::shared_ptr<Entity> en
 
 static bool data_node_is_leaf(path::DataNode & data_node)
 {
-    return (data_node.schema().get_statement().keyword == "leaf"
-            || data_node.schema().get_statement().keyword == "leaf-list");
+    return (data_node.get_schema_node().get_statement().keyword == "leaf"
+            || data_node.get_schema_node().get_statement().keyword == "leaf-list");
 }
 
 static bool data_node_is_list(path::DataNode & data_node)
 {
-    return (data_node.schema().get_statement().keyword == "list");
+    return (data_node.get_schema_node().get_statement().keyword == "list");
 }
 
 static string get_segment_path(const string & path)

--- a/sdk/cpp/core/src/executor_service.cpp
+++ b/sdk/cpp/core/src/executor_service.cpp
@@ -56,7 +56,7 @@ shared_ptr<Entity> ExecutorService::execute_rpc(NetconfServiceProvider & provide
     // Create RPC instance
     path::RootSchemaNode & root_schema = provider.get_root_schema();
     shared_ptr<path::Rpc> rpc = root_schema.create_rpc(yfilter);
-    path::DataNode & rpc_input = rpc->input();
+    path::DataNode & rpc_input = rpc->get_input_node();
 
     // Handle input
     auto input = rpc_entity.get_child_by_name("input", "");

--- a/sdk/cpp/core/src/executor_service.cpp
+++ b/sdk/cpp/core/src/executor_service.cpp
@@ -55,7 +55,7 @@ shared_ptr<Entity> ExecutorService::execute_rpc(NetconfServiceProvider & provide
 
     // Create RPC instance
     path::RootSchemaNode & root_schema = provider.get_root_schema();
-    shared_ptr<path::Rpc> rpc = root_schema.rpc(yfilter);
+    shared_ptr<path::Rpc> rpc = root_schema.create_rpc(yfilter);
     path::DataNode & rpc_input = rpc->input();
 
     // Handle input

--- a/sdk/cpp/core/src/executor_service.cpp
+++ b/sdk/cpp/core/src/executor_service.cpp
@@ -117,7 +117,7 @@ static void create_from_entity_path(std::shared_ptr<Entity> entity, path::DataNo
         if (path != "")
             temp_path = path + '/';
         temp_path = temp_path + child.first;
-        rpc_input.create(temp_path, child.second.value);
+        rpc_input.create_datanode(temp_path, child.second.value);
     }
 }
 
@@ -130,7 +130,7 @@ static void create_from_children(std::map<string, std::shared_ptr<Entity>> & chi
             YLOG_DEBUG("Creating child '{}': {}",child.first,
                 child.second->get_entity_path(child.second->parent).path);
 
-            rpc_input.create(child.first);
+            rpc_input.create_datanode(child.first);
         }
     }
 }

--- a/sdk/cpp/core/src/executor_service.cpp
+++ b/sdk/cpp/core/src/executor_service.cpp
@@ -69,7 +69,7 @@ shared_ptr<Entity> ExecutorService::execute_rpc(NetconfServiceProvider & provide
     auto output = rpc_entity.get_child_by_name("output", "");
     if (output != nullptr && result_datanode != nullptr)
     {
-        auto filter = result_datanode->children()[0].get();
+        auto filter = result_datanode->get_children()[0].get();
 
         get_entity_from_data_node(filter, top_entity);
         return top_entity;

--- a/sdk/cpp/core/src/netconf_provider.cpp
+++ b/sdk/cpp/core/src/netconf_provider.cpp
@@ -300,7 +300,7 @@ static string get_annotated_config_payload(path::RootSchemaNode & root_schema,
     }
 
     path::DataNode* entity_node = entity[0].get();
-    std::string entity_value = entity_node->get();
+    std::string entity_value = entity_node->get_value();
 
     //deserialize the entity_value
     auto datanode = codec_service.decode(root_schema, entity_value, EncodingFormat::XML);
@@ -332,7 +332,7 @@ static string get_filter_payload(path::Rpc & ydk_rpc)
     }
 
     auto datanode = entity[0];
-    return datanode->get();
+    return datanode->get_value();
 }
 
 static string get_netconf_payload(path::DataNode & input, string data_tag, string data_value)

--- a/sdk/cpp/core/src/netconf_provider.cpp
+++ b/sdk/cpp/core/src/netconf_provider.cpp
@@ -269,23 +269,23 @@ static bool is_candidate_supported(vector<string> capabilities)
 static void create_input_target(path::DataNode & input, bool candidate_supported)
 {
     if(candidate_supported){
-        input.create("target/candidate", "");
+        input.create_datanode("target/candidate", "");
     }
     else {
-        input.create("target/running", "");
+        input.create_datanode("target/running", "");
     }
 }
 
 static void create_input_error_option(path::DataNode & input)
 {
-    input.create("error-option", "rollback-on-error");
+    input.create_datanode("error-option", "rollback-on-error");
 }
 
 static void create_input_source(path::DataNode & input, bool config)
 {
     if(config)
     {
-        input.create("source/running");
+        input.create_datanode("source/running");
     }
 }
 
@@ -338,7 +338,7 @@ static string get_filter_payload(path::Rpc & ydk_rpc)
 static string get_netconf_payload(path::DataNode & input, string data_tag, string data_value)
 {
     path::Codec codec_service{};
-    input.create(data_tag, data_value);
+    input.create_datanode(data_tag, data_value);
 
     std::string payload{"<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"};
     payload+=codec_service.encode(input, EncodingFormat::XML, true);

--- a/sdk/cpp/core/src/netconf_provider.cpp
+++ b/sdk/cpp/core/src/netconf_provider.cpp
@@ -312,7 +312,7 @@ static string get_annotated_config_payload(path::RootSchemaNode & root_schema,
 
     std::string config_payload {};
 
-    for(auto const & child : datanode->children())
+    for(auto const & child : datanode->get_children())
     {
         if((child->annotations()).size()==0)
         {

--- a/sdk/cpp/core/src/netconf_provider.cpp
+++ b/sdk/cpp/core/src/netconf_provider.cpp
@@ -179,7 +179,7 @@ std::shared_ptr<path::DataNode> NetconfServiceProvider::handle_netconf_operation
     YLOG_INFO("\n");
 
     std::string reply = execute_payload(netconf_payload);
-    if (ydk_rpc.schema().get_path().find("get") != string::npos or ydk_rpc.schema().get_path().find("get-config") != string::npos)
+    if (ydk_rpc.get_schema_node().get_path().find("get") != string::npos or ydk_rpc.get_schema_node().get_path().find("get-config") != string::npos)
     {
         return handle_read_reply(reply, *root_schema);
     }
@@ -200,7 +200,7 @@ std::shared_ptr<path::DataNode> NetconfServiceProvider::invoke(path::Rpc& rpc) c
     path::SchemaNode* delete_schema = get_schema_for_operation(*root_schema, "ydk:delete");
 
     //for now we only support crud rpc's
-    path::SchemaNode* rpc_schema = &(rpc.schema());
+    path::SchemaNode* rpc_schema = &(rpc.get_schema_node());
     std::shared_ptr<path::DataNode> datanode = nullptr;
 
     if(rpc_schema == create_schema || rpc_schema == delete_schema || rpc_schema == update_schema)

--- a/sdk/cpp/core/src/netconf_provider.cpp
+++ b/sdk/cpp/core/src/netconf_provider.cpp
@@ -237,7 +237,7 @@ std::string NetconfServiceProvider::execute_payload(const std::string & payload)
 
 static shared_ptr<path::Rpc> create_rpc_instance(path::RootSchemaNode & root_schema, string rpc_name)
 {
-    auto rpc = shared_ptr<path::Rpc>(root_schema.rpc(rpc_name));
+    auto rpc = shared_ptr<path::Rpc>(root_schema.create_rpc(rpc_name));
     if(rpc == nullptr){
         YLOG_ERROR("Cannot create payload for RPC: {}", rpc_name);
         throw(YCPPIllegalStateError{"Cannot create payload for RPC: "+ rpc_name});

--- a/sdk/cpp/core/src/netconf_provider.cpp
+++ b/sdk/cpp/core/src/netconf_provider.cpp
@@ -179,7 +179,7 @@ std::shared_ptr<path::DataNode> NetconfServiceProvider::handle_netconf_operation
     YLOG_INFO("\n");
 
     std::string reply = execute_payload(netconf_payload);
-    if (ydk_rpc.schema().path().find("get") != string::npos or ydk_rpc.schema().path().find("get-config") != string::npos)
+    if (ydk_rpc.schema().get_path().find("get") != string::npos or ydk_rpc.schema().get_path().find("get-config") != string::npos)
     {
         return handle_read_reply(reply, *root_schema);
     }
@@ -213,7 +213,7 @@ std::shared_ptr<path::DataNode> NetconfServiceProvider::invoke(path::Rpc& rpc) c
     {
         return handle_read(rpc);
     }
-    else if(rpc_schema->path().find("ietf-netconf:")!= string::npos)
+    else if(rpc_schema->get_path().find("ietf-netconf:")!= string::npos)
     {
        return handle_netconf_operation(rpc);
     }

--- a/sdk/cpp/core/src/netconf_provider.cpp
+++ b/sdk/cpp/core/src/netconf_provider.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<path::DataNode> NetconfServiceProvider::handle_edit(path::Rpc& y
 std::shared_ptr<path::DataNode> NetconfServiceProvider::handle_netconf_operation(path::Rpc& ydk_rpc) const
 {
     path::Codec codec_service{};
-    auto netconf_payload = codec_service.encode(ydk_rpc.input(), EncodingFormat::XML, true);
+    auto netconf_payload = codec_service.encode(ydk_rpc.get_input_node(), EncodingFormat::XML, true);
     std::string payload{"<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">"};
     netconf_payload = payload + netconf_payload + "</rpc>";
 
@@ -247,7 +247,7 @@ static shared_ptr<path::Rpc> create_rpc_instance(path::RootSchemaNode & root_sch
 
 static path::DataNode& create_rpc_input(path::Rpc & netconf_rpc)
 {
-    return netconf_rpc.input();
+    return netconf_rpc.get_input_node();
 }
 
 static string get_commit_rpc_payload()
@@ -293,7 +293,7 @@ static string get_annotated_config_payload(path::RootSchemaNode & root_schema,
         path::Rpc & rpc, path::Annotation & annotation)
 {
     path::Codec codec_service{};
-    auto entity = rpc.input().find("entity");
+    auto entity = rpc.get_input_node().find("entity");
     if(entity.empty()){
         YLOG_ERROR("Failed to get entity node");
         throw(YCPPInvalidArgumentError{"Failed to get entity node"});
@@ -325,7 +325,7 @@ static string get_annotated_config_payload(path::RootSchemaNode & root_schema,
 
 static string get_filter_payload(path::Rpc & ydk_rpc)
 {
-    auto entity = ydk_rpc.input().find("filter");
+    auto entity = ydk_rpc.get_input_node().find("filter");
     if(entity.empty()){
         YLOG_ERROR("Failed to get entity node.");
         throw(YCPPInvalidArgumentError{"Failed to get entity node"});
@@ -425,7 +425,7 @@ static string get_read_rpc_name(bool config)
 
 static bool is_config(path::Rpc & rpc)
 {
-    if(!rpc.input().find("only-config").empty())
+    if(!rpc.get_input_node().find("only-config").empty())
     {
         return true;
     }

--- a/sdk/cpp/core/src/netconf_service.cpp
+++ b/sdk/cpp/core/src/netconf_service.cpp
@@ -61,7 +61,7 @@ bool NetconfService::cancel_commit(NetconfServiceProvider & provider, int persis
 
     if (persist_id > -1)
     {
-        rpc->input().create_datanode("persist-id", std::to_string(persist_id));
+        rpc->get_input_node().create_datanode("persist-id", std::to_string(persist_id));
     }
 
     auto read_datanode = (*rpc)(provider);
@@ -91,22 +91,22 @@ bool NetconfService::commit(NetconfServiceProvider & provider, bool confirmed,
 
     if (confirmed)
     {
-        rpc->input().create_datanode("confirmed");
+        rpc->get_input_node().create_datanode("confirmed");
     }
 
     if (confirm_timeout > -1)
     {
-        rpc->input().create_datanode("confirm-timeout", std::to_string(confirm_timeout));
+        rpc->get_input_node().create_datanode("confirm-timeout", std::to_string(confirm_timeout));
     }
 
     if (persist > -1)
     {
-        rpc->input().create_datanode("persist", std::to_string(persist));
+        rpc->get_input_node().create_datanode("persist", std::to_string(persist));
     }
 
     if (persist_id > -1)
     {
-        rpc->input().create_datanode("persist", std::to_string(persist_id));
+        rpc->get_input_node().create_datanode("persist", std::to_string(persist_id));
     }
 
     auto read_datanode = (*rpc)(provider);
@@ -122,8 +122,8 @@ bool NetconfService::copy_config(NetconfServiceProvider & provider, DataStore ta
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:copy-config");
 
     // target options: candidate | running | startup | url
-    create_input_leaf(rpc->input(), target, "target", url);
-    create_input_leaf(rpc->input(), source, "source", url);
+    create_input_leaf(rpc->get_input_node(), target, "target", url);
+    create_input_leaf(rpc->get_input_node(), source, "source", url);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -137,11 +137,11 @@ bool NetconfService::copy_config(NetconfServiceProvider & provider, DataStore ta
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:copy-config");
 
     // target options: candidate | running | startup | url
-    create_input_leaf(rpc->input(), target, "target");
+    create_input_leaf(rpc->get_input_node(), target, "target");
 
     // source
     std::string entity_string = get_data_payload(source, provider.get_root_schema());
-    rpc->input().create_datanode("source/config", entity_string);
+    rpc->get_input_node().create_datanode("source/config", entity_string);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -156,7 +156,7 @@ bool NetconfService::delete_config(NetconfServiceProvider & provider, DataStore 
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:delete-config");
 
     // target options: startup | url
-    create_input_leaf(rpc->input(), target, "target", url);
+    create_input_leaf(rpc->get_input_node(), target, "target", url);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -186,25 +186,25 @@ bool NetconfService::edit_config(NetconfServiceProvider & provider, DataStore ta
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:edit-config");
 
     // target options: candidate | running
-    create_input_leaf(rpc->input(), target, "target");
+    create_input_leaf(rpc->get_input_node(), target, "target");
 
     //config
     std::string entity_string = get_data_payload(config, provider.get_root_schema());
-    rpc->input().create_datanode("config", entity_string);
+    rpc->get_input_node().create_datanode("config", entity_string);
 
     if (default_operation.size() > 0)
     {
-        rpc->input().create_datanode("default-operation", default_operation);
+        rpc->get_input_node().create_datanode("default-operation", default_operation);
     }
 
     if (test_option.size() > 0)
     {
-        rpc->input().create_datanode("test-option", test_option);
+        rpc->get_input_node().create_datanode("test-option", test_option);
     }
 
     if (error_option.size() > 0)
     {
-        rpc->input().create_datanode("error-option", error_option);
+        rpc->get_input_node().create_datanode("error-option", error_option);
     }
 
     auto read_datanode = (*rpc)(provider);
@@ -220,11 +220,11 @@ shared_ptr<Entity> NetconfService::get_config(NetconfServiceProvider & provider,
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:get-config");
 
     // source options: candidate | running | startup
-    create_input_leaf(rpc->input(), source, "source");
+    create_input_leaf(rpc->get_input_node(), source, "source");
 
     // filter
     std::string filter_string  = get_xml_subtree_filter_payload(filter, provider);
-    rpc->input().create_datanode("filter", filter_string);
+    rpc->get_input_node().create_datanode("filter", filter_string);
 
     auto read_datanode = (*rpc)(provider);
     if (read_datanode == nullptr)
@@ -246,7 +246,7 @@ shared_ptr<Entity> NetconfService::get(NetconfServiceProvider & provider, Entity
 
     // filter
     std::string filter_string  = get_xml_subtree_filter_payload(filter, provider);
-    rpc->input().create_datanode("filter", filter_string);
+    rpc->get_input_node().create_datanode("filter", filter_string);
 
     auto result_datanode = (*rpc)(provider);
     if (result_datanode == nullptr)
@@ -265,7 +265,7 @@ bool NetconfService::kill_session(NetconfServiceProvider & provider, int session
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:kill-session");
 
     std::string sid_string = std::to_string(session_id);
-    rpc->input().create_datanode("session-id", sid_string);
+    rpc->get_input_node().create_datanode("session-id", sid_string);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -280,7 +280,7 @@ bool NetconfService::lock(NetconfServiceProvider & provider, DataStore target)
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:lock");
 
     // target options: candidate | running | startup
-    create_input_leaf(rpc->input(), target, "target");
+    create_input_leaf(rpc->get_input_node(), target, "target");
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -295,7 +295,7 @@ bool NetconfService::unlock(NetconfServiceProvider & provider, DataStore target)
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:unlock");
 
     // target options: candidate | running | startup
-    create_input_leaf(rpc->input(), target, "target");
+    create_input_leaf(rpc->get_input_node(), target, "target");
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -310,7 +310,7 @@ bool NetconfService::validate(NetconfServiceProvider & provider, DataStore sourc
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:validate");
 
     // source options: candidate | running | startup | url
-    create_input_leaf(rpc->input(), source, "source", url);
+    create_input_leaf(rpc->get_input_node(), source, "source", url);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -325,7 +325,7 @@ bool NetconfService::validate(NetconfServiceProvider & provider, Entity& source)
 
     // source
     std::string entity_string = get_data_payload(source, provider.get_root_schema());
-    rpc->input().create_datanode("source/config", entity_string);
+    rpc->get_input_node().create_datanode("source/config", entity_string);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;

--- a/sdk/cpp/core/src/netconf_service.cpp
+++ b/sdk/cpp/core/src/netconf_service.cpp
@@ -61,7 +61,7 @@ bool NetconfService::cancel_commit(NetconfServiceProvider & provider, int persis
 
     if (persist_id > -1)
     {
-        rpc->input().create("persist-id", std::to_string(persist_id));
+        rpc->input().create_datanode("persist-id", std::to_string(persist_id));
     }
 
     auto read_datanode = (*rpc)(provider);
@@ -91,22 +91,22 @@ bool NetconfService::commit(NetconfServiceProvider & provider, bool confirmed,
 
     if (confirmed)
     {
-        rpc->input().create("confirmed");
+        rpc->input().create_datanode("confirmed");
     }
 
     if (confirm_timeout > -1)
     {
-        rpc->input().create("confirm-timeout", std::to_string(confirm_timeout));
+        rpc->input().create_datanode("confirm-timeout", std::to_string(confirm_timeout));
     }
 
     if (persist > -1)
     {
-        rpc->input().create("persist", std::to_string(persist));
+        rpc->input().create_datanode("persist", std::to_string(persist));
     }
 
     if (persist_id > -1)
     {
-        rpc->input().create("persist", std::to_string(persist_id));
+        rpc->input().create_datanode("persist", std::to_string(persist_id));
     }
 
     auto read_datanode = (*rpc)(provider);
@@ -141,7 +141,7 @@ bool NetconfService::copy_config(NetconfServiceProvider & provider, DataStore ta
 
     // source
     std::string entity_string = get_data_payload(source, provider.get_root_schema());
-    rpc->input().create("source/config", entity_string);
+    rpc->input().create_datanode("source/config", entity_string);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -190,21 +190,21 @@ bool NetconfService::edit_config(NetconfServiceProvider & provider, DataStore ta
 
     //config
     std::string entity_string = get_data_payload(config, provider.get_root_schema());
-    rpc->input().create("config", entity_string);
+    rpc->input().create_datanode("config", entity_string);
 
     if (default_operation.size() > 0)
     {
-        rpc->input().create("default-operation", default_operation);
+        rpc->input().create_datanode("default-operation", default_operation);
     }
 
     if (test_option.size() > 0)
     {
-        rpc->input().create("test-option", test_option);
+        rpc->input().create_datanode("test-option", test_option);
     }
 
     if (error_option.size() > 0)
     {
-        rpc->input().create("error-option", error_option);
+        rpc->input().create_datanode("error-option", error_option);
     }
 
     auto read_datanode = (*rpc)(provider);
@@ -224,7 +224,7 @@ shared_ptr<Entity> NetconfService::get_config(NetconfServiceProvider & provider,
 
     // filter
     std::string filter_string  = get_xml_subtree_filter_payload(filter, provider);
-    rpc->input().create("filter", filter_string);
+    rpc->input().create_datanode("filter", filter_string);
 
     auto read_datanode = (*rpc)(provider);
     if (read_datanode == nullptr)
@@ -246,7 +246,7 @@ shared_ptr<Entity> NetconfService::get(NetconfServiceProvider & provider, Entity
 
     // filter
     std::string filter_string  = get_xml_subtree_filter_payload(filter, provider);
-    rpc->input().create("filter", filter_string);
+    rpc->input().create_datanode("filter", filter_string);
 
     auto result_datanode = (*rpc)(provider);
     if (result_datanode == nullptr)
@@ -265,7 +265,7 @@ bool NetconfService::kill_session(NetconfServiceProvider & provider, int session
     shared_ptr<path::Rpc> rpc = get_rpc_instance(provider, "ietf-netconf:kill-session");
 
     std::string sid_string = std::to_string(session_id);
-    rpc->input().create("session-id", sid_string);
+    rpc->input().create_datanode("session-id", sid_string);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -325,7 +325,7 @@ bool NetconfService::validate(NetconfServiceProvider & provider, Entity& source)
 
     // source
     std::string entity_string = get_data_payload(source, provider.get_root_schema());
-    rpc->input().create("source/config", entity_string);
+    rpc->input().create_datanode("source/config", entity_string);
 
     auto read_datanode = (*rpc)(provider);
     return read_datanode == nullptr;
@@ -373,7 +373,7 @@ static void create_input_leaf(path::DataNode & input_datanode, DataStore datasto
         }
         os << "/url";
 
-        input_datanode.create(os.str(), url);
+        input_datanode.create_datanode(os.str(), url);
     }
     else
     {
@@ -405,7 +405,7 @@ static void create_input_leaf(path::DataNode & input_datanode, DataStore datasto
             break;
     }
 
-    input_datanode.create(os.str());
+    input_datanode.create_datanode(os.str());
 }
 
 static string get_xml_subtree_filter_payload(Entity & entity, path::ServiceProvider & provider)

--- a/sdk/cpp/core/src/netconf_service.cpp
+++ b/sdk/cpp/core/src/netconf_service.cpp
@@ -334,7 +334,7 @@ bool NetconfService::validate(NetconfServiceProvider & provider, Entity& source)
 static shared_ptr<path::Rpc> get_rpc_instance(NetconfServiceProvider & provider, string && yfilter)
 {
     path::RootSchemaNode & root_schema = provider.get_root_schema();
-    auto rpc =  root_schema.rpc(yfilter);
+    auto rpc =  root_schema.create_rpc(yfilter);
     if (rpc == nullptr)
         throw(YCPPServiceProviderError{"Unable to create rpc"});
 

--- a/sdk/cpp/core/src/netconf_service.cpp
+++ b/sdk/cpp/core/src/netconf_service.cpp
@@ -231,7 +231,7 @@ shared_ptr<Entity> NetconfService::get_config(NetconfServiceProvider & provider,
         return nullptr;
 
     shared_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
-    get_entity_from_data_node(read_datanode->children()[0].get(), top_entity);
+    get_entity_from_data_node(read_datanode->get_children()[0].get(), top_entity);
     return top_entity;
 
 }
@@ -252,7 +252,7 @@ shared_ptr<Entity> NetconfService::get(NetconfServiceProvider & provider, Entity
     if (result_datanode == nullptr)
         return {};
     shared_ptr<Entity> top_entity = get_top_entity_from_filter(filter);
-    get_entity_from_data_node(result_datanode->children()[0].get(), top_entity);
+    get_entity_from_data_node(result_datanode->get_children()[0].get(), top_entity);
     return top_entity;
 }
 

--- a/sdk/cpp/core/src/netconf_service.cpp
+++ b/sdk/cpp/core/src/netconf_service.cpp
@@ -345,8 +345,8 @@ static std::string get_data_payload(Entity & entity, path::RootSchemaNode & root
 {
     path::DataNode& datanode = get_data_node_from_entity(entity, root_schema);
     const path::DataNode* dn = &datanode;
-    while(dn!= nullptr && dn->parent()!=nullptr)
-        dn = dn->parent();
+    while(dn!= nullptr && dn->get_parent()!=nullptr)
+        dn = dn->get_parent();
 
     path::Codec codec{};
     return codec.encode(*dn, ydk::EncodingFormat::XML, true);

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -308,7 +308,7 @@ ydk::path::DataNodeImpl::find(const std::string& path) const
 }
 
 ydk::path::DataNode*
-ydk::path::DataNodeImpl::parent() const
+ydk::path::DataNodeImpl::get_parent() const
 {
     return m_parent;
 }

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -68,7 +68,7 @@ ydk::path::DataNodeImpl::~DataNodeImpl()
 }
 
 const ydk::path::SchemaNode&
-ydk::path::DataNodeImpl::schema() const
+ydk::path::DataNodeImpl::get_schema_node() const
 {
     auto schema_ptr = reinterpret_cast<const SchemaNode*>(m_node->schema->priv);
     return *schema_ptr;
@@ -117,7 +117,7 @@ ydk::path::DataNodeImpl::create_helper(const std::string& path, const std::strin
     size_t start_index = 0;
     auto iter = segments.begin();
 
-    YLOG_DEBUG("Current path: {}", schema().get_path());
+    YLOG_DEBUG("Current path: {}", get_schema_node().get_path());
     YLOG_DEBUG("Top container path: {}", top_container_path);
 
     while (iter != segments.end())
@@ -277,7 +277,7 @@ ydk::path::DataNodeImpl::find(const std::string& path) const
     }
     std::string spath{path};
 
-    auto s = schema().get_statement();
+    auto s = get_schema_node().get_statement();
     if(s.keyword == "rpc"){
         spath="input/" + spath;
     }

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -277,7 +277,7 @@ ydk::path::DataNodeImpl::find(const std::string& path) const
     }
     std::string spath{path};
 
-    auto s = schema().statement();
+    auto s = schema().get_statement();
     if(s.keyword == "rpc"){
         spath="input/" + spath;
     }

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -36,9 +36,9 @@ ydk::path::DataNode::~DataNode()
 }
 
 ydk::path::DataNode&
-ydk::path::DataNode::create(const std::string& path)
+ydk::path::DataNode::create_datanode(const std::string& path)
 {
-    return create(path, "");
+    return create_datanode(path, "");
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -87,7 +87,7 @@ ydk::path::DataNodeImpl::get_path() const
 }
 
 ydk::path::DataNode&
-ydk::path::DataNodeImpl::create(const std::string& path, const std::string& value)
+ydk::path::DataNodeImpl::create_datanode(const std::string& path, const std::string& value)
 {
     return create_helper(path, value);
 }

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -225,7 +225,7 @@ ydk::path::DataNodeImpl::create_helper(const std::string& path, const std::strin
 }
 
 void
-ydk::path::DataNodeImpl::set(const std::string& value)
+ydk::path::DataNodeImpl::set_value(const std::string& value)
 {
     //set depends on the kind of the node
     lys_node* s_node = m_node->schema;

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -211,9 +211,9 @@ ydk::path::DataNodeImpl::create_helper(const std::string& path, const std::strin
 
         DataNodeImpl* rdn = dynamic_cast<DataNodeImpl*>(dn->child_map[first_node_created].get());
 
-        while(!rdn->children().empty() && rdn->m_node != cn)
+        while(!rdn->get_children().empty() && rdn->m_node != cn)
         {
-            rdn = dynamic_cast<DataNodeImpl*>(rdn->children()[0].get());
+            rdn = dynamic_cast<DataNodeImpl*>(rdn->get_children()[0].get());
         }
 
         return *rdn;
@@ -314,7 +314,7 @@ ydk::path::DataNodeImpl::get_parent() const
 }
 
 std::vector<std::shared_ptr<ydk::path::DataNode>>
-ydk::path::DataNodeImpl::children() const
+ydk::path::DataNodeImpl::get_children() const
 {
     std::vector<std::shared_ptr<DataNode>> ret{};
     //the ordering should be determined by the lyd_node

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -253,7 +253,7 @@ ydk::path::DataNodeImpl::set_value(const std::string& value)
 }
 
 std::string
-ydk::path::DataNodeImpl::get() const
+ydk::path::DataNodeImpl::get_value() const
 {
     lys_node* s_node = m_node->schema;
     std::string ret {};

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -336,10 +336,10 @@ ydk::path::DataNodeImpl::get_children() const
 }
 
 const ydk::path::DataNode&
-ydk::path::DataNodeImpl::root() const
+ydk::path::DataNodeImpl::get_root() const
 {
     if(m_parent){
-        return m_parent->root();
+        return m_parent->get_root();
     }
     return *this;
 }

--- a/sdk/cpp/core/src/path/data_node.cpp
+++ b/sdk/cpp/core/src/path/data_node.cpp
@@ -75,7 +75,7 @@ ydk::path::DataNodeImpl::schema() const
 }
 
 std::string
-ydk::path::DataNodeImpl::path() const
+ydk::path::DataNodeImpl::get_path() const
 {
     char* path = lyd_path(m_node);
     if (!path) {
@@ -117,7 +117,7 @@ ydk::path::DataNodeImpl::create_helper(const std::string& path, const std::strin
     size_t start_index = 0;
     auto iter = segments.begin();
 
-    YLOG_DEBUG("Current path: {}", schema().path());
+    YLOG_DEBUG("Current path: {}", schema().get_path());
     YLOG_DEBUG("Top container path: {}", top_container_path);
 
     while (iter != segments.end())
@@ -148,13 +148,13 @@ ydk::path::DataNodeImpl::create_helper(const std::string& path, const std::strin
             dn = dynamic_cast<DataNodeImpl*>(r[0].get());
             ++iter;
             start_index++;
-            YLOG_DEBUG("Found existing datanode with path '{}'", dn->path());
+            YLOG_DEBUG("Found existing datanode with path '{}'", dn->get_path());
 
             auto s = dn->m_node->schema;
             if (s->nodetype == LYS_LEAFLIST)
             {
-                YLOG_ERROR("Duplicate leaf-list item detected: {}", dn->path());
-                throw(YCPPModelError{"Duplicate leaf-list item detected: " + dn->path()});
+                YLOG_ERROR("Duplicate leaf-list item detected: {}", dn->get_path());
+                throw(YCPPModelError{"Duplicate leaf-list item detected: " + dn->get_path()});
             }
         }
     }

--- a/sdk/cpp/core/src/path/path.cpp
+++ b/sdk/cpp/core/src/path/path.cpp
@@ -160,7 +160,7 @@ ydk::path::ValidationService::validate(const ydk::path::DataNode & dn, ydk::Vali
     }
     ly_option = ly_option | LYD_OPT_NOAUTODEL;
 
-    YLOG_INFO("Validation called on {} with option {}", dn.path(), option_str);
+    YLOG_INFO("Validation called on {} with option {}", dn.get_path(), option_str);
 
     //what kind of a DataNode is this
     const ydk::path::DataNodeImpl & dn_impl = dynamic_cast<const ydk::path::DataNodeImpl&>(dn);

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -59,7 +59,7 @@ namespace ydk {
 
             std::vector<SchemaNode*> find(const std::string& path) const;
 
-            const SchemaNode* parent() const noexcept;
+            const SchemaNode* get_parent() const noexcept;
 
             const std::vector<std::unique_ptr<SchemaNode>>& children() const;
 
@@ -131,7 +131,7 @@ namespace ydk {
 
             virtual std::vector<std::shared_ptr<DataNode>> find(const std::string& path) const;
 
-            DataNode* parent() const;
+            DataNode* get_parent() const;
 
             virtual std::vector<std::shared_ptr<DataNode>> children() const;
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -127,7 +127,7 @@ namespace ydk {
 
             void set_value(const std::string& value);
 
-            virtual std::string get() const;
+            virtual std::string get_value() const;
 
             virtual std::vector<std::shared_ptr<DataNode>> find(const std::string& path) const;
 
@@ -174,7 +174,7 @@ namespace ydk {
 
             void set_value(const std::string& value);
 
-            std::string get() const;
+            std::string get_value() const;
 
             std::vector<std::shared_ptr<DataNode>> get_children() const;
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -55,7 +55,7 @@ namespace ydk {
 
             ~SchemaNodeImpl();
 
-            std::string path() const;
+            std::string get_path() const;
 
             std::vector<SchemaNode*> find(const std::string& path) const;
 
@@ -113,7 +113,7 @@ namespace ydk {
 
             virtual const SchemaNode& schema() const;
 
-            virtual std::string path() const;
+            virtual std::string get_path() const;
 
             // Create a new data node based on a simple XPath
             // The new node is normally inserted at the end, either as the last child of a parent.
@@ -168,7 +168,7 @@ namespace ydk {
 
             const SchemaNode& schema() const;
 
-            std::string path() const;
+            std::string get_path() const;
 
             DataNode& create(const std::string& path, const std::string& value);
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -61,7 +61,7 @@ namespace ydk {
 
             const SchemaNode* get_parent() const noexcept;
 
-            const std::vector<std::unique_ptr<SchemaNode>>& children() const;
+            const std::vector<std::unique_ptr<SchemaNode>>& get_children() const;
 
             const SchemaNode& root() const noexcept;
 
@@ -84,7 +84,7 @@ namespace ydk {
 
             std::vector<SchemaNode*> find(const std::string& path) const;
 
-            const std::vector<std::unique_ptr<SchemaNode>>& children() const;
+            const std::vector<std::unique_ptr<SchemaNode>>& get_children() const;
 
             DataNode& create(const std::string& path);
 
@@ -133,7 +133,7 @@ namespace ydk {
 
             DataNode* get_parent() const;
 
-            virtual std::vector<std::shared_ptr<DataNode>> children() const;
+            virtual std::vector<std::shared_ptr<DataNode>> get_children() const;
 
             virtual const DataNode& root() const;
 
@@ -176,7 +176,7 @@ namespace ydk {
 
             std::string get() const;
 
-            std::vector<std::shared_ptr<DataNode>> children() const;
+            std::vector<std::shared_ptr<DataNode>> get_children() const;
 
             const DataNode& root() const;
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -65,7 +65,7 @@ namespace ydk {
 
             const SchemaNode& get_root() const noexcept;
 
-            Statement statement() const;
+            Statement get_statement() const;
 
             std::vector<Statement> keys() const;
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -86,9 +86,9 @@ namespace ydk {
 
             const std::vector<std::unique_ptr<SchemaNode>>& get_children() const;
 
-            DataNode& create(const std::string& path);
+            DataNode& create_datanode(const std::string& path);
 
-            DataNode& create(const std::string& path, const std::string& value);
+            DataNode& create_datanode(const std::string& path, const std::string& value);
 
             std::shared_ptr<Rpc> rpc(const std::string& path) const;
 
@@ -123,7 +123,7 @@ namespace ydk {
             //
             // returns the first created or updated node
 
-            virtual DataNode& create(const std::string& path, const std::string& value);
+            virtual DataNode& create_datanode(const std::string& path, const std::string& value);
 
             void set(const std::string& value);
 
@@ -170,7 +170,7 @@ namespace ydk {
 
             std::string get_path() const;
 
-            DataNode& create(const std::string& path, const std::string& value);
+            DataNode& create_datanode(const std::string& path, const std::string& value);
 
             void set(const std::string& value);
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -198,7 +198,7 @@ namespace ydk {
 
             std::shared_ptr<DataNode> operator()(const ServiceProvider& provider);
 
-            DataNode& input() const;
+            DataNode& get_input_node() const;
 
             SchemaNode& get_schema_node() const;
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -90,7 +90,7 @@ namespace ydk {
 
             DataNode& create_datanode(const std::string& path, const std::string& value);
 
-            std::shared_ptr<Rpc> rpc(const std::string& path) const;
+            std::shared_ptr<Rpc> create_rpc(const std::string& path) const;
 
 
             struct ly_ctx* m_ctx;

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -63,7 +63,7 @@ namespace ydk {
 
             const std::vector<std::unique_ptr<SchemaNode>>& get_children() const;
 
-            const SchemaNode& root() const noexcept;
+            const SchemaNode& get_root() const noexcept;
 
             Statement statement() const;
 
@@ -135,7 +135,7 @@ namespace ydk {
 
             virtual std::vector<std::shared_ptr<DataNode>> get_children() const;
 
-            virtual const DataNode& root() const;
+            virtual const DataNode& get_root() const;
 
             void add_annotation(const Annotation& an);
 
@@ -178,7 +178,7 @@ namespace ydk {
 
             std::vector<std::shared_ptr<DataNode>> get_children() const;
 
-            const DataNode& root() const;
+            const DataNode& get_root() const;
 
             std::vector<std::shared_ptr<DataNode>> find(const std::string& path) const;
 

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -111,7 +111,7 @@ namespace ydk {
 
             virtual ~DataNodeImpl();
 
-            virtual const SchemaNode& schema() const;
+            virtual const SchemaNode& get_schema_node() const;
 
             virtual std::string get_path() const;
 
@@ -166,7 +166,7 @@ namespace ydk {
 
             ~RootDataImpl();
 
-            const SchemaNode& schema() const;
+            const SchemaNode& get_schema_node() const;
 
             std::string get_path() const;
 
@@ -200,7 +200,7 @@ namespace ydk {
 
             DataNode& input() const;
 
-            SchemaNode& schema() const;
+            SchemaNode& get_schema_node() const;
 
 
             SchemaNodeImpl& schema_node;

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -67,7 +67,7 @@ namespace ydk {
 
             Statement get_statement() const;
 
-            std::vector<Statement> keys() const;
+            std::vector<Statement> get_keys() const;
 
             const SchemaNode* m_parent;
             struct lys_node* m_node;

--- a/sdk/cpp/core/src/path/path_private.hpp
+++ b/sdk/cpp/core/src/path/path_private.hpp
@@ -125,7 +125,7 @@ namespace ydk {
 
             virtual DataNode& create_datanode(const std::string& path, const std::string& value);
 
-            void set(const std::string& value);
+            void set_value(const std::string& value);
 
             virtual std::string get() const;
 
@@ -172,7 +172,7 @@ namespace ydk {
 
             DataNode& create_datanode(const std::string& path, const std::string& value);
 
-            void set(const std::string& value);
+            void set_value(const std::string& value);
 
             std::string get() const;
 

--- a/sdk/cpp/core/src/path/root_data_node.cpp
+++ b/sdk/cpp/core/src/path/root_data_node.cpp
@@ -144,7 +144,7 @@ ydk::path::RootDataImpl::set_value(const std::string& value)
 }
 
 std::string
-ydk::path::RootDataImpl::get() const
+ydk::path::RootDataImpl::get_value() const
 {
     return "";
 }

--- a/sdk/cpp/core/src/path/root_data_node.cpp
+++ b/sdk/cpp/core/src/path/root_data_node.cpp
@@ -38,7 +38,7 @@ ydk::path::RootDataImpl::~RootDataImpl()
 }
 
 const ydk::path::SchemaNode&
-ydk::path::RootDataImpl::schema() const
+ydk::path::RootDataImpl::get_schema_node() const
 {
     return m_schema;
 }
@@ -194,7 +194,7 @@ ydk::path::RootDataImpl::find(const std::string& path) const
         schema_path+="/";
     }
 
-    auto s = schema().get_statement();
+    auto s = get_schema_node().get_statement();
     if(s.keyword == "rpc")
     {
         schema_path+="input/";

--- a/sdk/cpp/core/src/path/root_data_node.cpp
+++ b/sdk/cpp/core/src/path/root_data_node.cpp
@@ -44,9 +44,9 @@ ydk::path::RootDataImpl::schema() const
 }
 
 std::string
-ydk::path::RootDataImpl::path() const
+ydk::path::RootDataImpl::get_path() const
 {
-    return m_schema.path();
+    return m_schema.get_path();
 }
 
 ydk::path::DataNode&
@@ -188,7 +188,7 @@ ydk::path::RootDataImpl::find(const std::string& path) const
         return results;
     }
 
-    std::string schema_path{ this->path() };
+    std::string schema_path{ this->get_path() };
     if(schema_path.size()!= 1)
     {
         schema_path+="/";

--- a/sdk/cpp/core/src/path/root_data_node.cpp
+++ b/sdk/cpp/core/src/path/root_data_node.cpp
@@ -173,7 +173,7 @@ ydk::path::RootDataImpl::get_children() const
 }
 
 const ydk::path::DataNode&
-ydk::path::RootDataImpl::root() const
+ydk::path::RootDataImpl::get_root() const
 {
     return *this;
 }

--- a/sdk/cpp/core/src/path/root_data_node.cpp
+++ b/sdk/cpp/core/src/path/root_data_node.cpp
@@ -194,8 +194,7 @@ ydk::path::RootDataImpl::find(const std::string& path) const
         schema_path+="/";
     }
 
-    auto s = schema().
-    statement();
+    auto s = schema().get_statement();
     if(s.keyword == "rpc")
     {
         schema_path+="input/";

--- a/sdk/cpp/core/src/path/root_data_node.cpp
+++ b/sdk/cpp/core/src/path/root_data_node.cpp
@@ -135,7 +135,7 @@ ydk::path::RootDataImpl::create_datanode(const std::string& path, const std::str
  }
 
 void
-ydk::path::RootDataImpl::set(const std::string& value)
+ydk::path::RootDataImpl::set_value(const std::string& value)
 {
     if(!value.empty()) {
         YLOG_ERROR("Invalid value being assigned to root");

--- a/sdk/cpp/core/src/path/root_data_node.cpp
+++ b/sdk/cpp/core/src/path/root_data_node.cpp
@@ -50,7 +50,7 @@ ydk::path::RootDataImpl::get_path() const
 }
 
 ydk::path::DataNode&
-ydk::path::RootDataImpl::create(const std::string& path, const std::string& value)
+ydk::path::RootDataImpl::create_datanode(const std::string& path, const std::string& value)
 {
     if(path.empty())
     {
@@ -126,7 +126,7 @@ ydk::path::RootDataImpl::create(const std::string& path, const std::string& valu
             remaining_path+=segments[i];
         }
 
-        rdn = &(rdn->create(remaining_path));
+        rdn = &(rdn->create_datanode(remaining_path));
     }
 
 

--- a/sdk/cpp/core/src/path/root_data_node.cpp
+++ b/sdk/cpp/core/src/path/root_data_node.cpp
@@ -108,9 +108,9 @@ ydk::path::RootDataImpl::create(const std::string& path, const std::string& valu
 
     DataNode* rdn = dn;
     // created data node is the last child
-    while(!rdn->children().empty())
+    while(!rdn->get_children().empty())
     {
-        rdn = rdn->children()[0].get();
+        rdn = rdn->get_children()[0].get();
     }
 
     //at this stage we have dn so for the remaining segments use dn as the parent
@@ -151,7 +151,7 @@ ydk::path::RootDataImpl::get() const
 
 
 std::vector<std::shared_ptr<ydk::path::DataNode>>
-ydk::path::RootDataImpl::children() const
+ydk::path::RootDataImpl::get_children() const
 {
     std::vector<std::shared_ptr<DataNode>> ret{};
 

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -42,7 +42,7 @@ ydk::path::RootSchemaNode::path() const
 }
 
 ydk::path::SchemaNode*
-ydk::path::RootSchemaNode::parent() const noexcept
+ydk::path::RootSchemaNode::get_parent() const noexcept
 {
     return nullptr;
 }

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -129,7 +129,7 @@ ydk::path::RootSchemaNodeImpl::find(const std::string& path) const
 }
 
 const std::vector<std::unique_ptr<ydk::path::SchemaNode>> &
-ydk::path::RootSchemaNodeImpl::children() const
+ydk::path::RootSchemaNodeImpl::get_children() const
 {
     return m_children;
 }

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -36,7 +36,7 @@ ydk::path::RootSchemaNode::~RootSchemaNode()
 }
 
 std::string
-ydk::path::RootSchemaNode::path() const
+ydk::path::RootSchemaNode::get_path() const
 {
     return "/";
 }

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -135,17 +135,17 @@ ydk::path::RootSchemaNodeImpl::get_children() const
 }
 
 ydk::path::DataNode&
-ydk::path::RootSchemaNodeImpl::create(const std::string& path)
+ydk::path::RootSchemaNodeImpl::create_datanode(const std::string& path)
 {
-    return create(path, "");
+    return create_datanode(path, "");
 }
 
 ydk::path::DataNode&
-ydk::path::RootSchemaNodeImpl::create(const std::string& path, const std::string& value)
+ydk::path::RootSchemaNodeImpl::create_datanode(const std::string& path, const std::string& value)
 {
     auto root_data_node = std::make_unique<RootDataImpl>(*this, m_ctx, "/");
     m_root_data_nodes.push_back(std::move(root_data_node));
-    return m_root_data_nodes.back()->create(path, value);
+    return m_root_data_nodes.back()->create_datanode(path, value);
 }
 
 std::shared_ptr<ydk::path::Rpc>

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -48,7 +48,7 @@ ydk::path::RootSchemaNode::get_parent() const noexcept
 }
 
 const ydk::path::SchemaNode&
-ydk::path::RootSchemaNode::root() const noexcept
+ydk::path::RootSchemaNode::get_root() const noexcept
 {
     return *this;
 }

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -60,7 +60,7 @@ ydk::path::RootSchemaNode::get_statement() const
 }
 
 std::vector<ydk::path::Statement>
-ydk::path::RootSchemaNode::keys() const
+ydk::path::RootSchemaNode::get_keys() const
 {
     return std::vector<Statement>{};
 

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -149,7 +149,7 @@ ydk::path::RootSchemaNodeImpl::create_datanode(const std::string& path, const st
 }
 
 std::shared_ptr<ydk::path::Rpc>
-ydk::path::RootSchemaNodeImpl::rpc(const std::string& path) const
+ydk::path::RootSchemaNodeImpl::create_rpc(const std::string& path) const
 {
     auto c = find(path);
     if(c.empty()){

--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -54,7 +54,7 @@ ydk::path::RootSchemaNode::get_root() const noexcept
 }
 
 ydk::path::Statement
-ydk::path::RootSchemaNode::statement() const
+ydk::path::RootSchemaNode::get_statement() const
 {
     return Statement{};
 }
@@ -160,7 +160,7 @@ ydk::path::RootSchemaNodeImpl::rpc(const std::string& path) const
     SchemaNode* rpc_sn = nullptr;
 
     for(auto item : c) {
-        auto s = item->statement();
+        auto s = item->get_statement();
         if(s.keyword == "rpc"){
             found = true;
             rpc_sn = item;

--- a/sdk/cpp/core/src/path/rpc.cpp
+++ b/sdk/cpp/core/src/path/rpc.cpp
@@ -63,7 +63,7 @@ ydk::path::RpcImpl::operator()(const ydk::path::ServiceProvider& provider)
 
 
 ydk::path::DataNode&
-ydk::path::RpcImpl::input() const
+ydk::path::RpcImpl::get_input_node() const
 {
     return *data_node;
 }

--- a/sdk/cpp/core/src/path/rpc.cpp
+++ b/sdk/cpp/core/src/path/rpc.cpp
@@ -40,10 +40,10 @@ ydk::path::Rpc::~Rpc()
 ydk::path::RpcImpl::RpcImpl(SchemaNodeImpl& sn, struct ly_ctx* ctx) : schema_node{sn}
 {
 
-    struct lyd_node* dnode = lyd_new_path(nullptr, ctx, sn.path().c_str(), (void*)"", LYD_ANYDATA_SXML, 0);
+    struct lyd_node* dnode = lyd_new_path(nullptr, ctx, sn.get_path().c_str(), (void*)"", LYD_ANYDATA_SXML, 0);
 
     if(!dnode){
-        YLOG_ERROR("Cannot find DataNode with path {}", sn.path());
+        YLOG_ERROR("Cannot find DataNode with path {}", sn.get_path());
         throw(YCPPIllegalStateError{"Illegal state"});
     }
 

--- a/sdk/cpp/core/src/path/rpc.cpp
+++ b/sdk/cpp/core/src/path/rpc.cpp
@@ -69,7 +69,7 @@ ydk::path::RpcImpl::input() const
 }
 
 ydk::path::SchemaNode&
-ydk::path::RpcImpl::schema() const
+ydk::path::RpcImpl::get_schema_node() const
 {
     return schema_node;
 }

--- a/sdk/cpp/core/src/path/schema_node.cpp
+++ b/sdk/cpp/core/src/path/schema_node.cpp
@@ -132,7 +132,7 @@ ydk::path::SchemaNodeImpl::get_parent() const noexcept
 }
 
 const std::vector<std::unique_ptr<ydk::path::SchemaNode>> &
-ydk::path::SchemaNodeImpl::children() const
+ydk::path::SchemaNodeImpl::get_children() const
 {
 
     return m_children;

--- a/sdk/cpp/core/src/path/schema_node.cpp
+++ b/sdk/cpp/core/src/path/schema_node.cpp
@@ -230,7 +230,7 @@ ydk::path::SchemaNodeImpl::get_statement() const
 /// @return vector of Statement that represent keys
 ///
 std::vector<ydk::path::Statement>
-ydk::path::SchemaNodeImpl::keys() const
+ydk::path::SchemaNodeImpl::get_keys() const
 {
     std::vector<Statement> stmts{};
 

--- a/sdk/cpp/core/src/path/schema_node.cpp
+++ b/sdk/cpp/core/src/path/schema_node.cpp
@@ -157,7 +157,7 @@ static bool is_submodule(lys_node* node)
 }
 
 ydk::path::Statement
-ydk::path::SchemaNodeImpl::statement() const
+ydk::path::SchemaNodeImpl::get_statement() const
 {
     Statement s{};
     s.arg = m_node->name;
@@ -234,7 +234,7 @@ ydk::path::SchemaNodeImpl::keys() const
 {
     std::vector<Statement> stmts{};
 
-    Statement stmt = statement();
+    Statement stmt = get_statement();
     if(stmt.keyword == "list") {
         //sanity check
         if(m_node->nodetype != LYS_LIST) {
@@ -245,7 +245,7 @@ ydk::path::SchemaNodeImpl::keys() const
         for(uint8_t i=0; i < slist->keys_size; ++i) {
             SchemaNode* sn = reinterpret_cast<SchemaNode*>(slist->keys[i]->priv);
             if(sn != nullptr){
-                stmts.push_back(sn->statement());
+                stmts.push_back(sn->get_statement());
             }
         }
     }

--- a/sdk/cpp/core/src/path/schema_node.cpp
+++ b/sdk/cpp/core/src/path/schema_node.cpp
@@ -126,7 +126,7 @@ ydk::path::SchemaNodeImpl::find(const std::string& path) const
 }
 
 const ydk::path::SchemaNode*
-ydk::path::SchemaNodeImpl::parent() const noexcept
+ydk::path::SchemaNodeImpl::get_parent() const noexcept
 {
     return m_parent;
 }
@@ -252,5 +252,3 @@ ydk::path::SchemaNodeImpl::keys() const
 
     return stmts;
 }
-
-

--- a/sdk/cpp/core/src/path/schema_node.cpp
+++ b/sdk/cpp/core/src/path/schema_node.cpp
@@ -58,7 +58,7 @@ ydk::path::SchemaNodeImpl::~SchemaNodeImpl()
 }
 
 std::string
-ydk::path::SchemaNodeImpl::path() const
+ydk::path::SchemaNodeImpl::get_path() const
 {
     std::string ret{};
 

--- a/sdk/cpp/core/src/path/schema_node.cpp
+++ b/sdk/cpp/core/src/path/schema_node.cpp
@@ -139,7 +139,7 @@ ydk::path::SchemaNodeImpl::get_children() const
 }
 
 const ydk::path::SchemaNode&
-ydk::path::SchemaNodeImpl::root() const noexcept
+ydk::path::SchemaNodeImpl::get_root() const noexcept
 {
     if(m_parent == nullptr)
     {
@@ -147,7 +147,7 @@ ydk::path::SchemaNodeImpl::root() const noexcept
     }
     else
     {
-        return m_parent->root();
+        return m_parent->get_root();
     }
 }
 

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -529,7 +529,7 @@ public:
     /// Returns the YANG statement associated with this SchemaNode
     /// @return the yang statement for this SchemaNode
     ///
-    virtual Statement statement() const = 0;
+    virtual Statement get_statement() const = 0;
 
     ///
     /// @brief return YANG statement corresponding the the keys
@@ -641,7 +641,7 @@ public:
     /// So this method returns an empty statement.
     /// @return an empty statement
     ///
-   virtual Statement statement() const;
+   virtual Statement get_statement() const;
 
     ///
     /// @brief return vector of keys

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -506,7 +506,7 @@ public:
     /// Returns the parent Node of this SchemaNode in the tree
     /// @return pointer the parent Node or nullptr in case this is the root.
     ///
-    virtual const SchemaNode* parent() const noexcept = 0 ;
+    virtual const SchemaNode* get_parent() const noexcept = 0 ;
 
     ///
     /// @brief return the children of this SchemaNode in the NodeTree.
@@ -577,7 +577,7 @@ public:
     /// Returns the parent Node of this SchemaNode in the tree
     /// @return pointer the parent Node or nullptr in case this is the root.
     ///
-   virtual SchemaNode* parent() const noexcept;
+   virtual SchemaNode* get_parent() const noexcept;
 
     ///
     /// @brief return the children of this SchemaNode in the NodeTree.
@@ -774,7 +774,7 @@ public:
     ///
     /// Returns the parent of this DataNode or nullptr if None exist
     ///
-    virtual DataNode* parent() const = 0;
+    virtual DataNode* get_parent() const = 0;
 
     ///
     /// @brief returns the children of this DataNode

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -1029,7 +1029,7 @@ public:
     ///@return pointer to the input DataNode or nullptr if the rpc does not have
     /// an input element in the schema.
     ///
-    virtual DataNode& input() const = 0;
+    virtual DataNode& get_input_node() const = 0;
 
     ///
     /// @brief return the SchemaNode associated with this rpc

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -521,7 +521,7 @@ public:
     /// Returns the root of the NodeTree this nodes is part of
     /// @return the pointer to the root
     ///
-    virtual const SchemaNode& root() const noexcept = 0;
+    virtual const SchemaNode& get_root() const noexcept = 0;
 
     ///
     /// @brief return the YANG statement associated with this SchemaNode
@@ -592,7 +592,7 @@ public:
     /// Returns the root of the NodeTree this nodes is part of
     /// @return the pointer to the root
     ///
-    virtual const SchemaNode& root() const noexcept;
+    virtual const SchemaNode& get_root() const noexcept;
 
     ///
     /// @brief create a DataNode corresponding to the path and set its value
@@ -601,7 +601,7 @@ public:
     /// expression must identify a single node. If the last node created is of schema
     /// type list, leaf-list or anyxml that value is also set in the node.
     /// The returned DataNode is the last node created (the terminal part of the path).
-    /// The user is responsible for managing the memory of this returned tree. Use DataNode#root()
+    /// The user is responsible for managing the memory of this returned tree. Use DataNode#get_root()
     /// to get the root element of the this tree and use that pointer to dispose of the entire tree.
     /// Note in the case of List nodes the keys must be present in the path expression in the form
     /// of predicates.
@@ -622,7 +622,7 @@ public:
     /// expression must identify a single node. If the last node created is of schema
     /// type list, leaf-list or anyxml that value is also set in the node.
     /// The returned DataNode is the last node created (the terminal part of the path).
-    /// The user is responsible for managing the memory of this returned tree. Use DataNode#root()
+    /// The user is responsible for managing the memory of this returned tree. Use DataNode#get_root()
     /// to get the root element of the this tree and use that pointer to dispose of the entire tree.
     /// Note in the case of List nodes the keys must be present in the path expression in the form
     /// of predicates.
@@ -702,7 +702,7 @@ public:
     /// expression must identify a single node. If the last node created is of schema
     /// type list, leaf-list or anyxml that value is also set in the node.
     /// The returned DataNode is the last node created (the terminal part of the path).
-    /// The user is responsible for managing the memory of this returned tree. Use DataNode#root()
+    /// The user is responsible for managing the memory of this returned tree. Use DataNode#get_root()
     /// to get the root element of the this tree and use that pointer to dispose of the entire tree.
     /// Note in the case of List nodes the keys must be present in the path expression in the form
     /// of predicates.
@@ -722,7 +722,7 @@ public:
     /// expression must identify a single node. If the last node created is of schema
     /// type list, leaf-list or anyxml that value is also set in the node.
     /// The returned DataNode is the last node created (the terminal part of the path).
-    /// The user is responsible for managing the memory of this returned tree. Use DataNode#root()
+    /// The user is responsible for managing the memory of this returned tree. Use DataNode#get_root()
     /// to get the root element of the this tree and use that pointer to dispose of the entire tree.
     /// Note in the case of List nodes the keys must be present in the path expression in the form
     /// of predicates.
@@ -788,7 +788,7 @@ public:
     ///
     /// Returns the root of the DataNode.
     ///
-    virtual const DataNode& root() const = 0;
+    virtual const DataNode& get_root() const = 0;
 
     ///
     /// @brief Add the annotation to this datanode

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -513,7 +513,7 @@ public:
     ///
     /// Returns the children of this SchemaNode.
     ///@return the children of this node.
-    virtual const std::vector<std::unique_ptr<SchemaNode>> & children() const = 0;
+    virtual const std::vector<std::unique_ptr<SchemaNode>> & get_children() const = 0;
 
     ///
     /// @brief get the root of NodeTree this node is part of
@@ -584,7 +584,7 @@ public:
     ///
     /// Returns the children of this SchemaNode.
     ///@return the children of this node.
-    virtual const std::vector<std::unique_ptr<SchemaNode>>& children() const = 0;
+    virtual const std::vector<std::unique_ptr<SchemaNode>>& get_children() const = 0;
 
     ///
     /// @brief get the root of NodeTree this node is part of
@@ -781,7 +781,7 @@ public:
     ///
     /// Returns the children of this DataNode
     ///
-    virtual std::vector<std::shared_ptr<DataNode>> children() const = 0;
+    virtual std::vector<std::shared_ptr<DataNode>> get_children() const = 0;
 
     ///
     /// @brief returns the root DataNode of this tree.

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -660,7 +660,7 @@ public:
     /// @throws YCPPInvalidArgumentError if the argument is invalid.
     /// @throws YCPPPathError if the path is invalid
     ///
-    virtual std::shared_ptr<Rpc> rpc(const std::string& path) const = 0;
+    virtual std::shared_ptr<Rpc> create_rpc(const std::string& path) const = 0;
 
 };
 

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -613,7 +613,7 @@ public:
     /// @throws YCPPInvalidArgumentError In case the argument is invalid.
     /// @throws YCPPPathError In case the path is invalid.
     ///
-    virtual DataNode& create(const std::string& path, const std::string& value) = 0;
+    virtual DataNode& create_datanode(const std::string& path, const std::string& value) = 0;
 
     ///
     /// @brief create a DataNode corresponding to the path and set its value
@@ -632,7 +632,7 @@ public:
     /// @throws YCPPInvalidArgumentError In case the argument is invalid.
     /// @throws YCPPPathError In case the path is invalid.
     ///
-    virtual DataNode& create(const std::string& path)  = 0;
+    virtual DataNode& create_datanode(const std::string& path)  = 0;
 
     ///
     /// @brief return the Statement representing this SchemaNode
@@ -713,7 +713,7 @@ public:
     /// @throws YCPPInvalidArgumentError In case the argument is invalid.
     /// @throws YCPPPathError In case the path is invalid.
     ///
-   virtual DataNode& create(const std::string& path);
+   virtual DataNode& create_datanode(const std::string& path);
 
     ///
     /// @brief create a DataNode corresponding to the path and set its value
@@ -732,7 +732,7 @@ public:
     /// @throws YCPPInvalidArgumentError In case the argument is invalid.
     /// @throws YCPPPathError In case the path is invalid.
     ///
-    virtual DataNode& create(const std::string& path, const std::string& value) = 0;
+    virtual DataNode& create_datanode(const std::string& path, const std::string& value) = 0;
 
     ///
     /// @brief set the value of this DataNode.

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -685,7 +685,7 @@ public:
     /// Return the SchemaNode associated with this DataNode.
     /// @return SchemaNode associated with this DataNode
     ///
-    virtual const SchemaNode& schema() const = 0;
+    virtual const SchemaNode& get_schema_node() const = 0;
 
     ///
     /// @brief returns the XPath expression of this Node in the NodeTree
@@ -1035,7 +1035,7 @@ public:
     /// @brief return the SchemaNode associated with this rpc
     ///
     /// @return pointer to the SchemaNode associated with this rpc.
-    virtual SchemaNode& schema() const = 0;
+    virtual SchemaNode& get_schema_node() const = 0;
 
 
 };

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -756,7 +756,7 @@ public:
     ///
     // @returns The string representation of the value.
     ///
-    virtual std::string get() const = 0;
+    virtual std::string get_value() const = 0;
 
     ///
     /// @brief finds nodes that satisfy the given path expression.

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -745,7 +745,7 @@ public:
     /// @param[in] value The value to set. This should be the string representation of the YANG type.
     /// @throws YCPPInvalidArgumentError if the DataNode's value cannot be set (for example it represents
     /// a container)
-    virtual void set(const std::string& value) = 0;
+    virtual void set_value(const std::string& value) = 0;
 
 
 

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -486,7 +486,7 @@ public:
     /// Get the path expression representing this Node in in the NodeTree.
     /// @return std::string representing the path to this Node.
     ///
-    virtual std::string path() const = 0;
+    virtual std::string get_path() const = 0;
 
     ///
     /// @brief finds descendant nodes that match the given xpath expression
@@ -557,7 +557,7 @@ public:
     ///
    virtual ~RootSchemaNode();
 
-   std::string path() const;
+   std::string get_path() const;
 
     ///
     /// @brief finds descendant nodes that match the given xpath expression
@@ -693,7 +693,7 @@ public:
     /// Get the path expression representing this Node in in the NodeTree.
     /// @return std::string representing the path to this Node.
     ///
-    virtual std::string path() const = 0;
+    virtual std::string get_path() const = 0;
 
     ///
     /// @brief create a DataNode corresponding to the path and set its value

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -537,7 +537,7 @@ public:
     /// Returns the vector of Statement keys
     /// @return vector of Statement that represent keys
     ///
-    virtual std::vector<Statement> keys() const = 0;
+    virtual std::vector<Statement> get_keys() const = 0;
 
 };
 
@@ -649,7 +649,7 @@ public:
     /// For a root node this will always return an empty vector
     /// @return empty vector
     ///
-    virtual std::vector<Statement> keys() const;
+    virtual std::vector<Statement> get_keys() const;
 
     ///
     /// @brief create an rpc instance

--- a/sdk/cpp/core/src/restconf_provider.cpp
+++ b/sdk/cpp/core/src/restconf_provider.cpp
@@ -157,7 +157,7 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_read(path::Rpc& 
     }
 
     path::DataNode* filter_node = filter[0].get();
-    string filter_instance = filter_node->get();
+    string filter_instance = filter_node->get_value();
 
     auto datanode = codec_service.decode(*root_schema, filter_instance, encoding);
 
@@ -185,7 +185,7 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_edit(path::Rpc& 
     }
 
     path::DataNode* entity_node = entity[0].get();
-    string header_data = entity_node->get();
+    string header_data = entity_node->get_value();
 
     auto datanode = codec_service.decode(*root_schema, header_data, encoding);
     string url = config_url_root + get_module_url_path(datanode->get_children()[0]->get_schema_node().get_path());

--- a/sdk/cpp/core/src/restconf_provider.cpp
+++ b/sdk/cpp/core/src/restconf_provider.cpp
@@ -164,11 +164,11 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_read(path::Rpc& 
     string url;
     if(is_config(rpc))
     {
-        url = config_url_root + get_module_url_path(datanode->children()[0]->schema().path());
+        url = config_url_root + get_module_url_path(datanode->get_children()[0]->schema().path());
     }
     else
     {
-        url = state_url_root + get_module_url_path(datanode->children()[0]->schema().path());
+        url = state_url_root + get_module_url_path(datanode->get_children()[0]->schema().path());
     }
 
     YLOG_INFO("Performing GET on URL {}", url);
@@ -188,7 +188,7 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_edit(path::Rpc& 
     string header_data = entity_node->get();
 
     auto datanode = codec_service.decode(*root_schema, header_data, encoding);
-    string url = config_url_root + get_module_url_path(datanode->children()[0]->schema().path());
+    string url = config_url_root + get_module_url_path(datanode->get_children()[0]->schema().path());
 
     YLOG_INFO("Performing {} on URL {}. Payload: {}", yfilter, url, header_data);
     client->execute(yfilter, url, header_data);

--- a/sdk/cpp/core/src/restconf_provider.cpp
+++ b/sdk/cpp/core/src/restconf_provider.cpp
@@ -164,11 +164,11 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_read(path::Rpc& 
     string url;
     if(is_config(rpc))
     {
-        url = config_url_root + get_module_url_path(datanode->get_children()[0]->schema().path());
+        url = config_url_root + get_module_url_path(datanode->get_children()[0]->schema().get_path());
     }
     else
     {
-        url = state_url_root + get_module_url_path(datanode->get_children()[0]->schema().path());
+        url = state_url_root + get_module_url_path(datanode->get_children()[0]->schema().get_path());
     }
 
     YLOG_INFO("Performing GET on URL {}", url);
@@ -188,7 +188,7 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_edit(path::Rpc& 
     string header_data = entity_node->get();
 
     auto datanode = codec_service.decode(*root_schema, header_data, encoding);
-    string url = config_url_root + get_module_url_path(datanode->get_children()[0]->schema().path());
+    string url = config_url_root + get_module_url_path(datanode->get_children()[0]->schema().get_path());
 
     YLOG_INFO("Performing {} on URL {}. Payload: {}", yfilter, url, header_data);
     client->execute(yfilter, url, header_data);

--- a/sdk/cpp/core/src/restconf_provider.cpp
+++ b/sdk/cpp/core/src/restconf_provider.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::invoke(path::Rpc& rpc) 
     path::SchemaNode* update_schema = get_schema_for_operation(*root_schema, "ydk:update");
     path::SchemaNode* delete_schema = get_schema_for_operation(*root_schema, "ydk:delete");
 
-    path::SchemaNode* rpc_schema = &(rpc.schema());
+    path::SchemaNode* rpc_schema = &(rpc.get_schema_node());
     std::shared_ptr<path::DataNode> datanode = nullptr;
 
     if(rpc_schema == create_schema || rpc_schema == update_schema)
@@ -164,11 +164,11 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_read(path::Rpc& 
     string url;
     if(is_config(rpc))
     {
-        url = config_url_root + get_module_url_path(datanode->get_children()[0]->schema().get_path());
+        url = config_url_root + get_module_url_path(datanode->get_children()[0]->get_schema_node().get_path());
     }
     else
     {
-        url = state_url_root + get_module_url_path(datanode->get_children()[0]->schema().get_path());
+        url = state_url_root + get_module_url_path(datanode->get_children()[0]->get_schema_node().get_path());
     }
 
     YLOG_INFO("Performing GET on URL {}", url);
@@ -188,7 +188,7 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_edit(path::Rpc& 
     string header_data = entity_node->get();
 
     auto datanode = codec_service.decode(*root_schema, header_data, encoding);
-    string url = config_url_root + get_module_url_path(datanode->get_children()[0]->schema().get_path());
+    string url = config_url_root + get_module_url_path(datanode->get_children()[0]->get_schema_node().get_path());
 
     YLOG_INFO("Performing {} on URL {}. Payload: {}", yfilter, url, header_data);
     client->execute(yfilter, url, header_data);

--- a/sdk/cpp/core/src/restconf_provider.cpp
+++ b/sdk/cpp/core/src/restconf_provider.cpp
@@ -139,7 +139,7 @@ static string get_module_url_path(const string & path)
 
 static bool is_config(path::Rpc & rpc)
 {
-    if(!rpc.input().find("only-config").empty())
+    if(!rpc.get_input_node().find("only-config").empty())
     {
         return true;
     }
@@ -150,7 +150,7 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_read(path::Rpc& 
 {
     path::Codec codec_service{};
 
-    auto filter = rpc.input().find("filter");
+    auto filter = rpc.get_input_node().find("filter");
     if(filter.empty()){
         YLOG_ERROR("Failed to get entity node.");
         throw(YCPPInvalidArgumentError{"Failed to get entity node"});
@@ -178,7 +178,7 @@ std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_read(path::Rpc& 
 std::shared_ptr<path::DataNode> RestconfServiceProvider::handle_edit(path::Rpc& rpc, const string & yfilter) const
 {
     path::Codec codec_service{};
-    auto entity = rpc.input().find("entity");
+    auto entity = rpc.get_input_node().find("entity");
     if(entity.empty()){
         YLOG_ERROR("Failed to get entity node");
         throw(YCPPInvalidArgumentError{"Failed to get entity node"});

--- a/sdk/cpp/core/src/validation_service.cpp
+++ b/sdk/cpp/core/src/validation_service.cpp
@@ -39,8 +39,8 @@ ValidationService::validate(const path::ServiceProvider& sp, Entity& entity,
     path::RootSchemaNode& root_schema = sp.get_root_schema();
     const path::DataNode& datanode = get_data_node_from_entity(entity, root_schema);
     const path::DataNode* dn = &datanode;
-    while(dn!= nullptr && dn->parent()!=nullptr)
-        dn = dn->parent();
+    while(dn!= nullptr && dn->get_parent()!=nullptr)
+        dn = dn->get_parent();
 
     path::ValidationService path_validation_service{};
     path_validation_service.validate(*dn, option);

--- a/sdk/cpp/core/tests/bgptest.cpp
+++ b/sdk/cpp/core/tests/bgptest.cpp
@@ -379,7 +379,7 @@ TEST_CASE( "submodule" )
 //    REQUIRE(schema.get() != nullptr);
 //
 //    auto subtest = schema->create("ydktest-sanity:sub-test", "");
-//    std::cout<<subtest->schema()->path()<<std::endl;
+//    std::cout<<subtest->schema()->get_path()<<std::endl;
 //
 //    REQUIRE( subtest != nullptr );
 //

--- a/sdk/cpp/core/tests/bgptest.cpp
+++ b/sdk/cpp/core/tests/bgptest.cpp
@@ -55,7 +55,7 @@ public:
     {
         ydk::path::Codec s{};
 
-        std::cout << s.encode(rpc.input(), ydk::EncodingFormat::XML, true) << std::endl;
+        std::cout << s.encode(rpc.get_input_node(), ydk::EncodingFormat::XML, true) << std::endl;
 
         return nullptr;
     }
@@ -274,7 +274,7 @@ TEST_CASE( "bgp" )
 
 
     auto create_rpc = schema.create_rpc("ydk:create") ;
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
 
     //call create
     (*create_rpc)(sp);

--- a/sdk/cpp/core/tests/bgptest.cpp
+++ b/sdk/cpp/core/tests/bgptest.cpp
@@ -384,7 +384,7 @@ TEST_CASE( "submodule" )
 //    REQUIRE( subtest != nullptr );
 //
 //    //get the root
-//    std::unique_ptr<const ydk::path::DataNode> data_root{subtest->root()};
+//    std::unique_ptr<const ydk::path::DataNode> data_root{subtest->get_root()};
 //
 //    REQUIRE( data_root != nullptr );
 //

--- a/sdk/cpp/core/tests/bgptest.cpp
+++ b/sdk/cpp/core/tests/bgptest.cpp
@@ -376,7 +376,7 @@ TEST_CASE( "submodule" )
 //
 //    std::unique_ptr<ydk::path::RootSchemaNode> schema{sp.get_root_schema()};
 //
-//    REQUIRE(schema.get() != nullptr);
+//    REQUIRE(schema.get_value() != nullptr);
 //
 //    auto subtest = schema->create_datanode("ydktest-sanity:sub-test", "");
 //    std::cout<<subtest->get_schema_node()->get_path()<<std::endl;

--- a/sdk/cpp/core/tests/bgptest.cpp
+++ b/sdk/cpp/core/tests/bgptest.cpp
@@ -273,7 +273,7 @@ TEST_CASE( "bgp" )
     REQUIRE(new_json == expected_bgp_json);
 
 
-    auto create_rpc = schema.rpc("ydk:create") ;
+    auto create_rpc = schema.create_rpc("ydk:create") ;
     create_rpc->input().create_datanode("entity", xml);
 
     //call create

--- a/sdk/cpp/core/tests/bgptest.cpp
+++ b/sdk/cpp/core/tests/bgptest.cpp
@@ -379,7 +379,7 @@ TEST_CASE( "submodule" )
 //    REQUIRE(schema.get() != nullptr);
 //
 //    auto subtest = schema->create_datanode("ydktest-sanity:sub-test", "");
-//    std::cout<<subtest->schema()->get_path()<<std::endl;
+//    std::cout<<subtest->get_schema_node()->get_path()<<std::endl;
 //
 //    REQUIRE( subtest != nullptr );
 //

--- a/sdk/cpp/core/tests/bgptest.cpp
+++ b/sdk/cpp/core/tests/bgptest.cpp
@@ -208,30 +208,30 @@ TEST_CASE( "bgp" )
 
     auto & schema = sp.get_root_schema();
 
-    auto & bgp = schema.create("openconfig-bgp:bgp", "");
+    auto & bgp = schema.create_datanode("openconfig-bgp:bgp", "");
 
-    auto & as = bgp.create("global/config/as", "65172");
+    auto & as = bgp.create_datanode("global/config/as", "65172");
 
-    auto & l3vpn_ipv4_unicast = bgp.create("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    auto & l3vpn_ipv4_unicast = bgp.create_datanode("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
 
-    auto & afi_safi_name = l3vpn_ipv4_unicast.create("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    auto & afi_safi_name = l3vpn_ipv4_unicast.create_datanode("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
 
     //set the enable flag
-    auto & enable = l3vpn_ipv4_unicast.create("config/enabled","true");
+    auto & enable = l3vpn_ipv4_unicast.create_datanode("config/enabled","true");
 
     //bgp/neighbors/neighbor
-    auto & neighbor = bgp.create("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
+    auto & neighbor = bgp.create_datanode("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
 
-    auto & neighbor_address = neighbor.create("config/neighbor-address", "172.16.255.2");
+    auto & neighbor_address = neighbor.create_datanode("config/neighbor-address", "172.16.255.2");
 
-    auto & peer_as = neighbor.create("config/peer-as","65172");
+    auto & peer_as = neighbor.create_datanode("config/peer-as","65172");
 
     //bgp/neighbors/neighbor/afi-safis/afi-safi
-    auto & neighbor_af = neighbor.create("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    auto & neighbor_af = neighbor.create_datanode("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
 
-    auto & neighbor_afi_safi_name = neighbor_af.create("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    auto & neighbor_afi_safi_name = neighbor_af.create_datanode("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
 
-    auto & neighbor_enabled = neighbor_af.create("config/enabled","true");
+    auto & neighbor_enabled = neighbor_af.create_datanode("config/enabled","true");
 
     ydk::path::Codec s{};
 
@@ -274,7 +274,7 @@ TEST_CASE( "bgp" )
 
 
     auto create_rpc = schema.rpc("ydk:create") ;
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
 
     //call create
     (*create_rpc)(sp);
@@ -288,38 +288,38 @@ TEST_CASE( "bgp_validation" )
 
     auto & schema = sp.get_root_schema();
 
-    auto & bgp = schema.create("openconfig-bgp:bgp", "");
+    auto & bgp = schema.create_datanode("openconfig-bgp:bgp", "");
 
-    auto & as = bgp.create("global/config/as", "65172");
+    auto & as = bgp.create_datanode("global/config/as", "65172");
 
-    auto & l3vpn_ipv4_unicast = bgp.create("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    auto & l3vpn_ipv4_unicast = bgp.create_datanode("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
 
-    auto & afi_safi_name = l3vpn_ipv4_unicast.create("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    auto & afi_safi_name = l3vpn_ipv4_unicast.create_datanode("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
 
     //set the enable flag
-    auto & enable = l3vpn_ipv4_unicast.create("config/enabled","true");
+    auto & enable = l3vpn_ipv4_unicast.create_datanode("config/enabled","true");
 
     //bgp/neighbors/neighbor
-    auto & neighbor = bgp.create("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
+    auto & neighbor = bgp.create_datanode("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
 
-    //auto & peer_group = neighbor.create("config/peer-group", "IBGP");
+    //auto & peer_group = neighbor.create_datanode("config/peer-group", "IBGP");
 
-    auto & neighbor_address = neighbor.create("config/neighbor-address", "172.16.255.2");
+    auto & neighbor_address = neighbor.create_datanode("config/neighbor-address", "172.16.255.2");
 
-    auto & peer_as = neighbor.create("config/peer-as","65172");
+    auto & peer_as = neighbor.create_datanode("config/peer-as","65172");
 
-    auto & neighbor_remove_as = neighbor.create("config/remove-private-as", "openconfig-bgp-types:PRIVATE_AS_REMOVE_ALL");
+    auto & neighbor_remove_as = neighbor.create_datanode("config/remove-private-as", "openconfig-bgp-types:PRIVATE_AS_REMOVE_ALL");
 
     //bgp/neighbors/neighbor/afi-safis/afi-safi
-    auto & neighbor_af = neighbor.create("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    auto & neighbor_af = neighbor.create_datanode("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
 
-    auto & neighbor_afi_safi_name = neighbor_af.create("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    auto & neighbor_afi_safi_name = neighbor_af.create_datanode("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
 
-    auto & neighbor_enabled = neighbor_af.create("config/enabled","true");
+    auto & neighbor_enabled = neighbor_af.create_datanode("config/enabled","true");
 
-    auto & peer_group = bgp.create("peer-groups/peer-group[peer-group-name='IBGP']", "");
-    auto & peer_group_name = peer_group.create("config/peer-group-name", "IBGP");
-    peer_as = peer_group.create("config/peer-as", "65172");
+    auto & peer_group = bgp.create_datanode("peer-groups/peer-group[peer-group-name='IBGP']", "");
+    auto & peer_group_name = peer_group.create_datanode("config/peer-group-name", "IBGP");
+    peer_as = peer_group.create_datanode("config/peer-as", "65172");
 
     ydk::path::ValidationService validation_service{};
 
@@ -357,9 +357,9 @@ TEST_CASE( "bits_order" )
     auto & schema = sp.get_root_schema();
 
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
-    auto  & bits = runner.create("ytypes/built-in-t/bits-value", "auto-sense-speed disable-nagle");
+    auto  & bits = runner.create_datanode("ytypes/built-in-t/bits-value", "auto-sense-speed disable-nagle");
 
     auto new_xml = s.encode(
         runner, ydk::EncodingFormat::XML, false);
@@ -378,7 +378,7 @@ TEST_CASE( "submodule" )
 //
 //    REQUIRE(schema.get() != nullptr);
 //
-//    auto subtest = schema->create("ydktest-sanity:sub-test", "");
+//    auto subtest = schema->create_datanode("ydktest-sanity:sub-test", "");
 //    std::cout<<subtest->schema()->get_path()<<std::endl;
 //
 //    REQUIRE( subtest != nullptr );
@@ -388,10 +388,10 @@ TEST_CASE( "submodule" )
 //
 //    REQUIRE( data_root != nullptr );
 //
-//    auto name = subtest->create("ydktest-sanity:sub-test/one-aug/name", "test");
+//    auto name = subtest->create_datanode("ydktest-sanity:sub-test/one-aug/name", "test");
 //    REQUIRE( name!= nullptr );
 //
-//    auto number = subtest->create("ydktest-sanity:sub-test/one-aug/number", "3");
+//    auto number = subtest->create_datanode("ydktest-sanity:sub-test/one-aug/number", "3");
 //    REQUIRE( number!= nullptr );
 
 //    auto ne1w_xml = s.encode(*subtest, ydk::EncodingFormat::XML, false);

--- a/sdk/cpp/core/tests/models/tailf-common.yang
+++ b/sdk/cpp/core/tests/models/tailf-common.yang
@@ -1094,7 +1094,7 @@ module tailf-common {
     }
     tailf:use-in "tailf:transaction-hook";
     description
-      "By default, the node-specific write callbacks (create(), set_elem(),
+      "By default, the node-specific write callbacks (create_datanode(), set_elem(),
       etc) for a transaction hook are invoked for the invidual data nodes
       that are modified in the transaction. If 'tailf:invocation-mode' is
       set to 'per-transaction', there will instead be a single invocation

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -70,7 +70,7 @@ const char* expected_bgp_read ="<bgp xmlns=\"http://openconfig.net/yang/bgp\"><g
 
 void print_tree(ydk::path::DataNode* dn, const std::string& indent)
 {
-    ydk::path::Statement s = dn->schema().statement();
+    ydk::path::Statement s = dn->schema().get_statement();
     if(s.keyword == "leaf" || s.keyword == "leaf-list" || s.keyword == "anyxml") {
         auto val = dn->get();
         std::cout << indent << "<" << s.arg << ">" << val << "</" << s.arg << ">" << std::endl;

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -98,7 +98,7 @@ TEST_CASE( "bgp_netconf_create" )
 
     auto & bgp = schema.create_datanode("openconfig-bgp:bgp", "");
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 
@@ -138,12 +138,12 @@ TEST_CASE( "bgp_netconf_create" )
     REQUIRE(xml == expected_bgp_output);
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & bgp_read = schema.create_datanode("openconfig-bgp:bgp", "");
 
     xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
@@ -163,7 +163,7 @@ TEST_CASE( "bgp_netconf_create" )
     peer_as.set("6500");
 
     //call update
-    std::shared_ptr<ydk::path::Rpc> update_rpc { schema.rpc("ydk:update") };
+    std::shared_ptr<ydk::path::Rpc> update_rpc { schema.create_rpc("ydk:update") };
     xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
     update_rpc->input().create_datanode("entity", xml);
@@ -191,7 +191,7 @@ TEST_CASE("bits")
 
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 }
@@ -215,7 +215,7 @@ TEST_CASE("core_validate")
     std::cout << xml << std::endl;
 
     //call create
-    // std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    // std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     // create_rpc->input().create_datanode("entity", xml);
     // (*create_rpc)(sp);
 }
@@ -252,7 +252,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
     auto & peer_group_name = ppeer_group.create_datanode("config/peer-group-name", "IBGP");
     auto & ppeer_as = ppeer_group.create_datanode("config/peer-as","65172");
 
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
     create_rpc->input().create_datanode("entity", xml);
@@ -260,7 +260,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
     auto res = (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & bgp_read = schema.create_datanode("openconfig-bgp:bgp", "");
 
 
@@ -298,7 +298,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
 //
 //    auto & vrf = four_instance_as->create_datanode("vrfs/vrf[vrf-name='red']");
 //
-//  std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+//  std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
 //  auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 //  REQUIRE( !xml.empty() );
 //  create_rpc->input().create_datanode("entity", xml);
@@ -306,7 +306,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
 //  auto res = (*create_rpc)(sp);
 //
 //  //call read
-//    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+//    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
 //    auto & bgp_read = schema.create_datanode("Cisco-IOS-XR-ipv4-bgp-cfg:bgp", "");
 //    std::shared_ptr<const ydk::path::DataNode> data_root2{&bgp_read.get_root()};
 //

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -72,7 +72,7 @@ void print_tree(ydk::path::DataNode* dn, const std::string& indent)
 {
     ydk::path::Statement s = dn->get_schema_node().get_statement();
     if(s.keyword == "leaf" || s.keyword == "leaf-list" || s.keyword == "anyxml") {
-        auto val = dn->get();
+        auto val = dn->get_value();
         std::cout << indent << "<" << s.arg << ">" << val << "</" << s.arg << ">" << std::endl;
     } else {
         std::string child_indent{indent};

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -96,40 +96,40 @@ TEST_CASE( "bgp_netconf_create" )
 
     ydk::path::Codec s{};
 
-    auto & bgp = schema.create("openconfig-bgp:bgp", "");
+    auto & bgp = schema.create_datanode("openconfig-bgp:bgp", "");
     //first delete
     std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
 
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
 
-    auto & as = bgp.create("global/config/as", "65172");
+    auto & as = bgp.create_datanode("global/config/as", "65172");
 
-    auto & l3vpn_ipv4_unicast = bgp.create("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    auto & l3vpn_ipv4_unicast = bgp.create_datanode("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
 
-    auto & afi_safi_name = l3vpn_ipv4_unicast.create("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    auto & afi_safi_name = l3vpn_ipv4_unicast.create_datanode("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
 
     //set the enable flag
-    auto & enable = l3vpn_ipv4_unicast.create("config/enabled","true");
+    auto & enable = l3vpn_ipv4_unicast.create_datanode("config/enabled","true");
 
     //bgp/neighbors/neighbor
-    auto & neighbor = bgp.create("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
+    auto & neighbor = bgp.create_datanode("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
 
-    auto & neighbor_address = neighbor.create("config/neighbor-address", "172.16.255.2");
+    auto & neighbor_address = neighbor.create_datanode("config/neighbor-address", "172.16.255.2");
 
-    auto & peer_as = neighbor.create("config/peer-as","65172");
+    auto & peer_as = neighbor.create_datanode("config/peer-as","65172");
 
     //bgp/neighbors/neighbor/afi-safis/afi-safi
-    auto & neighbor_af = neighbor.create("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    auto & neighbor_af = neighbor.create_datanode("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
 
-    auto & neighbor_afi_safi_name = neighbor_af.create("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    auto & neighbor_afi_safi_name = neighbor_af.create_datanode("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
 
-    auto & neighbor_enabled = neighbor_af.create("config/enabled","true");
+    auto & neighbor_enabled = neighbor_af.create_datanode("config/enabled","true");
 
     xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 
@@ -139,16 +139,16 @@ TEST_CASE( "bgp_netconf_create" )
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & bgp_read = schema.create("openconfig-bgp:bgp", "");
+    auto & bgp_read = schema.create_datanode("openconfig-bgp:bgp", "");
 
     xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -166,7 +166,7 @@ TEST_CASE( "bgp_netconf_create" )
     std::shared_ptr<ydk::path::Rpc> update_rpc { schema.rpc("ydk:update") };
     xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    update_rpc->input().create("entity", xml);
+    update_rpc->input().create_datanode("entity", xml);
     (*update_rpc)(sp);
 
 
@@ -180,9 +180,9 @@ TEST_CASE("bits")
     ydk::NetconfServiceProvider sp{repo,"127.0.0.1", "admin", "admin",  12022};
     ydk::path::RootSchemaNode& schema = sp.get_root_schema();
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
-    auto & ysanity = runner.create("ytypes/built-in-t/bits-value", "disable-nagle");
+    auto & ysanity = runner.create_datanode("ytypes/built-in-t/bits-value", "disable-nagle");
 
     ydk::path::Codec s{};
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
@@ -192,7 +192,7 @@ TEST_CASE("bits")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 }
 
@@ -203,9 +203,9 @@ TEST_CASE("core_validate")
     ydk::NetconfServiceProvider sp{repo,"127.0.0.1", "admin", "admin",  12022};
     ydk::path::RootSchemaNode& schema = sp.get_root_schema();
 
-    auto & runner = schema.create("ietf-netconf:validate", "");
+    auto & runner = schema.create_datanode("ietf-netconf:validate", "");
 
-    auto & ysanity = runner.create("source/candidate", "");
+    auto & ysanity = runner.create_datanode("source/candidate", "");
 
     ydk::path::Codec s{};
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
@@ -216,7 +216,7 @@ TEST_CASE("core_validate")
 
     //call create
     // std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    // create_rpc->input().create("entity", xml);
+    // create_rpc->input().create_datanode("entity", xml);
     // (*create_rpc)(sp);
 }
 
@@ -230,46 +230,46 @@ TEST_CASE( "bgp_xr_openconfig"  )
 
     ydk::path::Codec s{};
 
-    auto & bgp = schema.create("openconfig-bgp:bgp", "");
+    auto & bgp = schema.create_datanode("openconfig-bgp:bgp", "");
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&bgp.get_root());
 
     REQUIRE( data_root != nullptr );
 
     //call create
-    auto & as = bgp.create("global/config/as", "65172");
-    auto & router_id = bgp.create("global/config/router-id", "1.2.3.4");
-    auto & l3vpn_ipv4_unicast = bgp.create("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
-    auto & afi_safi_name = l3vpn_ipv4_unicast.create("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
-    auto & enable = l3vpn_ipv4_unicast.create("config/enabled","true");
+    auto & as = bgp.create_datanode("global/config/as", "65172");
+    auto & router_id = bgp.create_datanode("global/config/router-id", "1.2.3.4");
+    auto & l3vpn_ipv4_unicast = bgp.create_datanode("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "");
+    auto & afi_safi_name = l3vpn_ipv4_unicast.create_datanode("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST");
+    auto & enable = l3vpn_ipv4_unicast.create_datanode("config/enabled","true");
     //bgp/neighbors/neighbor
-    auto & neighbor = bgp.create("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
-    auto & neighbor_address = neighbor.create("config/neighbor-address", "172.16.255.2");
-    auto & peer_as = neighbor.create("config/peer-as","65172");
-    auto & peer_group = neighbor.create("config/peer-group","IBGP");
+    auto & neighbor = bgp.create_datanode("neighbors/neighbor[neighbor-address='172.16.255.2']", "");
+    auto & neighbor_address = neighbor.create_datanode("config/neighbor-address", "172.16.255.2");
+    auto & peer_as = neighbor.create_datanode("config/peer-as","65172");
+    auto & peer_group = neighbor.create_datanode("config/peer-group","IBGP");
     //bgp/peer-groups/peer-group
-    auto & ppeer_group = bgp.create("peer-groups/peer-group[peer-group-name='IBGP']", "");
-    auto & peer_group_name = ppeer_group.create("config/peer-group-name", "IBGP");
-    auto & ppeer_as = ppeer_group.create("config/peer-as","65172");
+    auto & ppeer_group = bgp.create_datanode("peer-groups/peer-group[peer-group-name='IBGP']", "");
+    auto & peer_group_name = ppeer_group.create_datanode("config/peer-group-name", "IBGP");
+    auto & ppeer_as = ppeer_group.create_datanode("config/peer-as","65172");
 
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
 
     auto res = (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & bgp_read = schema.create("openconfig-bgp:bgp", "");
+    auto & bgp_read = schema.create_datanode("openconfig-bgp:bgp", "");
 
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&bgp_read.get_root());
 
     xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
-    read_rpc->input().create("only-config");
+    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->input().create_datanode("only-config");
 
     auto read_result = (*read_rpc)(sp);
 
@@ -287,33 +287,33 @@ TEST_CASE( "bgp_xr_openconfig"  )
 //
 //    ydk::path::Codec s{};
 //
-//    auto & bgp = schema.create("Cisco-IOS-XR-ipv4-bgp-cfg:bgp", "");
+//    auto & bgp = schema.create_datanode("Cisco-IOS-XR-ipv4-bgp-cfg:bgp", "");
 //
 //    //call create
-//    auto & instance = bgp.create("instance[instance-name='65172']");
+//    auto & instance = bgp.create_datanode("instance[instance-name='65172']");
 //
-//    auto & instance_as = instance->create("instance-as[as='65172']");
+//    auto & instance_as = instance->create_datanode("instance-as[as='65172']");
 //
-//    auto & four_instance_as = instance_as->create("four-byte-as[as='65172']");
+//    auto & four_instance_as = instance_as->create_datanode("four-byte-as[as='65172']");
 //
-//    auto & vrf = four_instance_as->create("vrfs/vrf[vrf-name='red']");
+//    auto & vrf = four_instance_as->create_datanode("vrfs/vrf[vrf-name='red']");
 //
 //  std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
 //  auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 //  REQUIRE( !xml.empty() );
-//  create_rpc->input().create("entity", xml);
+//  create_rpc->input().create_datanode("entity", xml);
 //
 //  auto res = (*create_rpc)(sp);
 //
 //  //call read
 //    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-//    auto & bgp_read = schema.create("Cisco-IOS-XR-ipv4-bgp-cfg:bgp", "");
+//    auto & bgp_read = schema.create_datanode("Cisco-IOS-XR-ipv4-bgp-cfg:bgp", "");
 //    std::shared_ptr<const ydk::path::DataNode> data_root2{&bgp_read.get_root()};
 //
 //    xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
 //    REQUIRE( !xml.empty() );
-//    read_rpc->input().create("filter", xml);
-//    read_rpc->input().create("only-config");
+//    read_rpc->input().create_datanode("filter", xml);
+//    read_rpc->input().create_datanode("only-config");
 //
 //    auto read_result = (*read_rpc)(sp);
 //

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -102,7 +102,7 @@ TEST_CASE( "bgp_netconf_create" )
 
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -139,7 +139,7 @@ TEST_CASE( "bgp_netconf_create" )
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -148,7 +148,7 @@ TEST_CASE( "bgp_netconf_create" )
 
     xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -166,7 +166,7 @@ TEST_CASE( "bgp_netconf_create" )
     std::shared_ptr<ydk::path::Rpc> update_rpc { schema.create_rpc("ydk:update") };
     xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    update_rpc->input().create_datanode("entity", xml);
+    update_rpc->get_input_node().create_datanode("entity", xml);
     (*update_rpc)(sp);
 
 
@@ -192,7 +192,7 @@ TEST_CASE("bits")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 }
 
@@ -216,7 +216,7 @@ TEST_CASE("core_validate")
 
     //call create
     // std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    // create_rpc->input().create_datanode("entity", xml);
+    // create_rpc->get_input_node().create_datanode("entity", xml);
     // (*create_rpc)(sp);
 }
 
@@ -255,7 +255,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
 
     auto res = (*create_rpc)(sp);
 
@@ -268,8 +268,8 @@ TEST_CASE( "bgp_xr_openconfig"  )
 
     xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
-    read_rpc->input().create_datanode("only-config");
+    read_rpc->get_input_node().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("only-config");
 
     auto read_result = (*read_rpc)(sp);
 
@@ -301,7 +301,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
 //  std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
 //  auto xml = s.encode(bgp, ydk::EncodingFormat::XML, false);
 //  REQUIRE( !xml.empty() );
-//  create_rpc->input().create_datanode("entity", xml);
+//  create_rpc->get_input_node().create_datanode("entity", xml);
 //
 //  auto res = (*create_rpc)(sp);
 //
@@ -312,8 +312,8 @@ TEST_CASE( "bgp_xr_openconfig"  )
 //
 //    xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
 //    REQUIRE( !xml.empty() );
-//    read_rpc->input().create_datanode("filter", xml);
-//    read_rpc->input().create_datanode("only-config");
+//    read_rpc->get_input_node().create_datanode("filter", xml);
+//    read_rpc->get_input_node().create_datanode("only-config");
 //
 //    auto read_result = (*read_rpc)(sp);
 //

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -70,7 +70,7 @@ const char* expected_bgp_read ="<bgp xmlns=\"http://openconfig.net/yang/bgp\"><g
 
 void print_tree(ydk::path::DataNode* dn, const std::string& indent)
 {
-    ydk::path::Statement s = dn->schema().get_statement();
+    ydk::path::Statement s = dn->get_schema_node().get_statement();
     if(s.keyword == "leaf" || s.keyword == "leaf-list" || s.keyword == "anyxml") {
         auto val = dn->get();
         std::cout << indent << "<" << s.arg << ">" << val << "</" << s.arg << ">" << std::endl;

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -232,7 +232,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
 
     auto & bgp = schema.create("openconfig-bgp:bgp", "");
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&bgp.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&bgp.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -264,7 +264,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
     auto & bgp_read = schema.create("openconfig-bgp:bgp", "");
 
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&bgp_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&bgp_read.get_root());
 
     xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -308,7 +308,7 @@ TEST_CASE( "bgp_xr_openconfig"  )
 //  //call read
 //    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
 //    auto & bgp_read = schema.create("Cisco-IOS-XR-ipv4-bgp-cfg:bgp", "");
-//    std::shared_ptr<const ydk::path::DataNode> data_root2{&bgp_read.root()};
+//    std::shared_ptr<const ydk::path::DataNode> data_root2{&bgp_read.get_root()};
 //
 //    xml = s.encode(bgp_read, ydk::EncodingFormat::XML, false);
 //    REQUIRE( !xml.empty() );

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -78,7 +78,7 @@ void print_tree(ydk::path::DataNode* dn, const std::string& indent)
         std::string child_indent{indent};
         child_indent+="  ";
         std::cout << indent << "<" << s.arg << ">" << std::endl;
-        for(auto c : dn->children())
+        for(auto c : dn->get_children())
         print_tree(c.get(), child_indent);
         std::cout << indent << "</" << s.arg << ">" << std::endl;
 

--- a/sdk/cpp/tests/test_core_netconf.cpp
+++ b/sdk/cpp/tests/test_core_netconf.cpp
@@ -160,7 +160,7 @@ TEST_CASE( "bgp_netconf_create" )
 
     REQUIRE(xml == expected_bgp_read);
 
-    peer_as.set("6500");
+    peer_as.set_value("6500");
 
     //call update
     std::shared_ptr<ydk::path::Rpc> update_rpc { schema.create_rpc("ydk:update") };

--- a/sdk/cpp/tests/test_restconf_provider.cpp
+++ b/sdk/cpp/tests/test_restconf_provider.cpp
@@ -36,7 +36,7 @@ TEST_CASE("CreateDelRead")
     auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
     auto json = s.encode(runner, EncodingFormat::JSON, false);
     delete_rpc->input().create_datanode("entity", json);
     //call delete
@@ -47,12 +47,12 @@ TEST_CASE("CreateDelRead")
     json = s.encode(runner, EncodingFormat::JSON, false);
     CHECK( !json.empty());
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", json);
     (*create_rpc)(provider);
 
     //read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     json = s.encode(runner_read, EncodingFormat::JSON, false);
@@ -67,7 +67,7 @@ TEST_CASE("CreateDelRead")
     json = s.encode(runner, EncodingFormat::JSON, false);
     CHECK( !json.empty());
     //call update
-    std::shared_ptr<ydk::path::Rpc> update_rpc { schema.rpc("ydk:update") };
+    std::shared_ptr<ydk::path::Rpc> update_rpc { schema.create_rpc("ydk:update") };
     update_rpc->input().create_datanode("entity", json);
     (*update_rpc)(provider);
 

--- a/sdk/cpp/tests/test_restconf_provider.cpp
+++ b/sdk/cpp/tests/test_restconf_provider.cpp
@@ -33,44 +33,43 @@ TEST_CASE("CreateDelRead")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //first delete
     std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
     auto json = s.encode(runner, EncodingFormat::JSON, false);
-    delete_rpc->input().create("entity", json);
+    delete_rpc->input().create_datanode("entity", json);
     //call delete
     (*delete_rpc)(provider);
 
-    auto & number8 = runner.create("ytypes/built-in-t/number8", "3");
+    auto & number8 = runner.create_datanode("ytypes/built-in-t/number8", "3");
 
     json = s.encode(runner, EncodingFormat::JSON, false);
     CHECK( !json.empty());
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", json);
+    create_rpc->input().create_datanode("entity", json);
     (*create_rpc)(provider);
 
     //read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     json = s.encode(runner_read, EncodingFormat::JSON, false);
     REQUIRE( !json.empty() );
-    read_rpc->input().create("filter", json);
+    read_rpc->input().create_datanode("filter", json);
 
     auto read_result = (*read_rpc)(provider);
 
-    runner = schema.create("ydktest-sanity:runner", "");
-    number8 = runner.create("ytypes/built-in-t/number8", "5");
+    runner = schema.create_datanode("ydktest-sanity:runner", "");
+    number8 = runner.create_datanode("ytypes/built-in-t/number8", "5");
 
     json = s.encode(runner, EncodingFormat::JSON, false);
     CHECK( !json.empty());
     //call update
     std::shared_ptr<ydk::path::Rpc> update_rpc { schema.rpc("ydk:update") };
-    update_rpc->input().create("entity", json);
+    update_rpc->input().create_datanode("entity", json);
     (*update_rpc)(provider);
 
 
 }
-

--- a/sdk/cpp/tests/test_restconf_provider.cpp
+++ b/sdk/cpp/tests/test_restconf_provider.cpp
@@ -38,7 +38,7 @@ TEST_CASE("CreateDelRead")
     //first delete
     std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
     auto json = s.encode(runner, EncodingFormat::JSON, false);
-    delete_rpc->input().create_datanode("entity", json);
+    delete_rpc->get_input_node().create_datanode("entity", json);
     //call delete
     (*delete_rpc)(provider);
 
@@ -48,7 +48,7 @@ TEST_CASE("CreateDelRead")
     CHECK( !json.empty());
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", json);
+    create_rpc->get_input_node().create_datanode("entity", json);
     (*create_rpc)(provider);
 
     //read
@@ -57,7 +57,7 @@ TEST_CASE("CreateDelRead")
 
     json = s.encode(runner_read, EncodingFormat::JSON, false);
     REQUIRE( !json.empty() );
-    read_rpc->input().create_datanode("filter", json);
+    read_rpc->get_input_node().create_datanode("filter", json);
 
     auto read_result = (*read_rpc)(provider);
 
@@ -68,7 +68,7 @@ TEST_CASE("CreateDelRead")
     CHECK( !json.empty());
     //call update
     std::shared_ptr<ydk::path::Rpc> update_rpc { schema.create_rpc("ydk:update") };
-    update_rpc->input().create_datanode("entity", json);
+    update_rpc->get_input_node().create_datanode("entity", json);
     (*update_rpc)(provider);
 
 

--- a/sdk/cpp/tests/testsanitynctest.cpp
+++ b/sdk/cpp/tests/testsanitynctest.cpp
@@ -52,7 +52,7 @@ TEST_CASE("test_sanity_types_int8 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -66,7 +66,7 @@ TEST_CASE("test_sanity_types_int8 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -77,7 +77,7 @@ TEST_CASE("test_sanity_types_int8 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -118,7 +118,7 @@ TEST_CASE("test_sanity_types_int16 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -133,7 +133,7 @@ TEST_CASE("test_sanity_types_int16 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -144,7 +144,7 @@ TEST_CASE("test_sanity_types_int16 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -185,7 +185,7 @@ TEST_CASE("test_sanity_types_int32 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -198,7 +198,7 @@ TEST_CASE("test_sanity_types_int32 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -209,7 +209,7 @@ TEST_CASE("test_sanity_types_int32 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -248,7 +248,7 @@ TEST_CASE("test_sanity_types_int64 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -261,7 +261,7 @@ TEST_CASE("test_sanity_types_int64 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -272,7 +272,7 @@ TEST_CASE("test_sanity_types_int64 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -311,7 +311,7 @@ TEST_CASE("test_sanity_types_uint8 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -325,7 +325,7 @@ TEST_CASE("test_sanity_types_uint8 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -336,7 +336,7 @@ TEST_CASE("test_sanity_types_uint8 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -375,7 +375,7 @@ TEST_CASE("test_sanity_types_uint16 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -389,7 +389,7 @@ TEST_CASE("test_sanity_types_uint16 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -400,7 +400,7 @@ TEST_CASE("test_sanity_types_uint16 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -439,7 +439,7 @@ TEST_CASE("test_sanity_types_uint32 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -454,7 +454,7 @@ TEST_CASE("test_sanity_types_uint32 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -465,7 +465,7 @@ TEST_CASE("test_sanity_types_uint32 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -504,7 +504,7 @@ TEST_CASE("test_sanity_types_uint64 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -517,7 +517,7 @@ TEST_CASE("test_sanity_types_uint64 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -528,7 +528,7 @@ TEST_CASE("test_sanity_types_uint64 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -569,7 +569,7 @@ TEST_CASE("test_sanity_types_bits ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -583,7 +583,7 @@ TEST_CASE("test_sanity_types_bits ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -594,7 +594,7 @@ TEST_CASE("test_sanity_types_bits ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -633,7 +633,7 @@ TEST_CASE("test_sanity_types_decimal64 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -646,7 +646,7 @@ TEST_CASE("test_sanity_types_decimal64 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -657,7 +657,7 @@ TEST_CASE("test_sanity_types_decimal64 ")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -699,7 +699,7 @@ TEST_CASE("test_sanity_types_string")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -712,7 +712,7 @@ TEST_CASE("test_sanity_types_string")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -723,7 +723,7 @@ TEST_CASE("test_sanity_types_string")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -764,7 +764,7 @@ TEST_CASE("test_sanity_types_empty")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -777,7 +777,7 @@ TEST_CASE("test_sanity_types_empty")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -788,7 +788,7 @@ TEST_CASE("test_sanity_types_empty")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -827,7 +827,7 @@ TEST_CASE("test_sanity_types_boolean")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -840,7 +840,7 @@ TEST_CASE("test_sanity_types_boolean")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -851,7 +851,7 @@ TEST_CASE("test_sanity_types_boolean")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -891,7 +891,7 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -904,7 +904,7 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -915,7 +915,7 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -954,7 +954,7 @@ TEST_CASE("test_sanity_types_enum")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -967,7 +967,7 @@ TEST_CASE("test_sanity_types_enum")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -978,7 +978,7 @@ TEST_CASE("test_sanity_types_enum")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1018,7 +1018,7 @@ TEST_CASE("test_sanity_types_union")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -1031,7 +1031,7 @@ TEST_CASE("test_sanity_types_union")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -1042,7 +1042,7 @@ TEST_CASE("test_sanity_types_union")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1082,7 +1082,7 @@ TEST_CASE("test_sanity_types_union_enum")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -1095,7 +1095,7 @@ TEST_CASE("test_sanity_types_union_enum")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -1106,7 +1106,7 @@ TEST_CASE("test_sanity_types_union_enum")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1148,7 +1148,7 @@ TEST_CASE("test_sanity_types_union_int")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -1162,7 +1162,7 @@ TEST_CASE("test_sanity_types_union_int")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -1173,7 +1173,7 @@ TEST_CASE("test_sanity_types_union_int")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1214,7 +1214,7 @@ TEST_CASE("test_union_leaflist")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -1229,7 +1229,7 @@ TEST_CASE("test_union_leaflist")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -1240,7 +1240,7 @@ TEST_CASE("test_union_leaflist")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1279,7 +1279,7 @@ TEST_CASE("test_enum_leaflist")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -1294,7 +1294,7 @@ TEST_CASE("test_enum_leaflist")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -1305,7 +1305,7 @@ TEST_CASE("test_enum_leaflist")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1344,7 +1344,7 @@ TEST_CASE("test_identity_leaflist")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -1359,7 +1359,7 @@ TEST_CASE("test_identity_leaflist")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -1370,7 +1370,7 @@ TEST_CASE("test_identity_leaflist")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1410,7 +1410,7 @@ TEST_CASE("test_union_complex_list")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -1423,7 +1423,7 @@ TEST_CASE("test_union_complex_list")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -1434,7 +1434,7 @@ TEST_CASE("test_union_complex_list")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1469,7 +1469,7 @@ TEST_CASE("test_identityref")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create_datanode("entity", xml);
+    delete_rpc->get_input_node().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
@@ -1482,7 +1482,7 @@ TEST_CASE("test_identityref")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
-    create_rpc->input().create_datanode("entity", xml);
+    create_rpc->get_input_node().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
@@ -1493,7 +1493,7 @@ TEST_CASE("test_identityref")
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create_datanode("filter", xml);
+    read_rpc->get_input_node().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 

--- a/sdk/cpp/tests/testsanitynctest.cpp
+++ b/sdk/cpp/tests/testsanitynctest.cpp
@@ -42,10 +42,8 @@ TEST_CASE("test_sanity_types_int8 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -75,7 +73,7 @@ TEST_CASE("test_sanity_types_int8 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -110,10 +108,8 @@ TEST_CASE("test_sanity_types_int16 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -144,7 +140,7 @@ TEST_CASE("test_sanity_types_int16 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -179,10 +175,8 @@ TEST_CASE("test_sanity_types_int32 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -211,7 +205,7 @@ TEST_CASE("test_sanity_types_int32 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -244,10 +238,8 @@ TEST_CASE("test_sanity_types_int64 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -276,7 +268,7 @@ TEST_CASE("test_sanity_types_int64 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -309,10 +301,8 @@ TEST_CASE("test_sanity_types_uint8 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -342,7 +332,7 @@ TEST_CASE("test_sanity_types_uint8 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -375,10 +365,8 @@ TEST_CASE("test_sanity_types_uint16 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -408,7 +396,7 @@ TEST_CASE("test_sanity_types_uint16 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -441,10 +429,8 @@ TEST_CASE("test_sanity_types_uint32 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -475,7 +461,7 @@ TEST_CASE("test_sanity_types_uint32 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -508,10 +494,8 @@ TEST_CASE("test_sanity_types_uint64 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -540,7 +524,7 @@ TEST_CASE("test_sanity_types_uint64 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -575,10 +559,8 @@ TEST_CASE("test_sanity_types_bits ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -608,7 +590,7 @@ TEST_CASE("test_sanity_types_bits ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -641,10 +623,8 @@ TEST_CASE("test_sanity_types_decimal64 ")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -673,7 +653,7 @@ TEST_CASE("test_sanity_types_decimal64 ")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -709,10 +689,8 @@ TEST_CASE("test_sanity_types_string")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -741,7 +719,7 @@ TEST_CASE("test_sanity_types_string")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -776,10 +754,8 @@ TEST_CASE("test_sanity_types_empty")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -808,7 +784,7 @@ TEST_CASE("test_sanity_types_empty")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -841,10 +817,8 @@ TEST_CASE("test_sanity_types_boolean")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -873,7 +847,7 @@ TEST_CASE("test_sanity_types_boolean")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -907,10 +881,8 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -939,7 +911,7 @@ TEST_CASE("test_sanity_types_embedded_enum")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -972,10 +944,8 @@ TEST_CASE("test_sanity_types_enum")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1004,7 +974,7 @@ TEST_CASE("test_sanity_types_enum")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1038,10 +1008,8 @@ TEST_CASE("test_sanity_types_union")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1070,7 +1038,7 @@ TEST_CASE("test_sanity_types_union")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1104,10 +1072,8 @@ TEST_CASE("test_sanity_types_union_enum")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1136,7 +1102,7 @@ TEST_CASE("test_sanity_types_union_enum")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1172,10 +1138,8 @@ TEST_CASE("test_sanity_types_union_int")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1205,7 +1169,7 @@ TEST_CASE("test_sanity_types_union_int")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1240,10 +1204,8 @@ TEST_CASE("test_union_leaflist")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1274,7 +1236,7 @@ TEST_CASE("test_union_leaflist")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1307,10 +1269,8 @@ TEST_CASE("test_enum_leaflist")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1341,7 +1301,7 @@ TEST_CASE("test_enum_leaflist")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1374,10 +1334,8 @@ TEST_CASE("test_identity_leaflist")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1408,7 +1366,7 @@ TEST_CASE("test_identity_leaflist")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1442,10 +1400,8 @@ TEST_CASE("test_union_complex_list")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1474,7 +1430,7 @@ TEST_CASE("test_union_complex_list")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1503,10 +1459,8 @@ TEST_CASE("test_identityref")
 
     auto & runner = schema.create("ydktest-sanity:runner", "");
 
-
-
     //get the root
-    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.root());
+    const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
 
     REQUIRE( data_root != nullptr );
 
@@ -1535,8 +1489,7 @@ TEST_CASE("test_identityref")
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
     auto & runner_read = schema.create("ydktest-sanity:runner", "");
 
-
-    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.root());
+    const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
@@ -1556,4 +1509,3 @@ TEST_CASE("test_identityref")
     REQUIRE(val == "ydktest-sanity:child-child-identity");
 
 }
-

--- a/sdk/cpp/tests/testsanitynctest.cpp
+++ b/sdk/cpp/tests/testsanitynctest.cpp
@@ -40,7 +40,7 @@ TEST_CASE("test_sanity_types_int8 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -52,12 +52,12 @@ TEST_CASE("test_sanity_types_int8 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & number8 = runner.create("ytypes/built-in-t/number8", "0");
+    auto & number8 = runner.create_datanode("ytypes/built-in-t/number8", "0");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -66,18 +66,18 @@ TEST_CASE("test_sanity_types_int8 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -106,7 +106,7 @@ TEST_CASE("test_sanity_types_int16 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -118,12 +118,12 @@ TEST_CASE("test_sanity_types_int16 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & number16 = runner.create("ytypes/built-in-t/number16", "126");
+    auto & number16 = runner.create_datanode("ytypes/built-in-t/number16", "126");
 
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
@@ -133,18 +133,18 @@ TEST_CASE("test_sanity_types_int16 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -173,7 +173,7 @@ TEST_CASE("test_sanity_types_int32 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -185,12 +185,12 @@ TEST_CASE("test_sanity_types_int32 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & number32 = runner.create("ytypes/built-in-t/number32", "200000");
+    auto & number32 = runner.create_datanode("ytypes/built-in-t/number32", "200000");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -198,18 +198,18 @@ TEST_CASE("test_sanity_types_int32 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -236,7 +236,7 @@ TEST_CASE("test_sanity_types_int64 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -248,12 +248,12 @@ TEST_CASE("test_sanity_types_int64 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & number64 = runner.create("ytypes/built-in-t/number64", "-9223372036854775808");
+    auto & number64 = runner.create_datanode("ytypes/built-in-t/number64", "-9223372036854775808");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -261,18 +261,18 @@ TEST_CASE("test_sanity_types_int64 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -299,7 +299,7 @@ TEST_CASE("test_sanity_types_uint8 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -311,12 +311,12 @@ TEST_CASE("test_sanity_types_uint8 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & unumber8 = runner.create("ytypes/built-in-t/u_number8", "0");
+    auto & unumber8 = runner.create_datanode("ytypes/built-in-t/u_number8", "0");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -325,18 +325,18 @@ TEST_CASE("test_sanity_types_uint8 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -363,7 +363,7 @@ TEST_CASE("test_sanity_types_uint16 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -375,12 +375,12 @@ TEST_CASE("test_sanity_types_uint16 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & unumber16 = runner.create("ytypes/built-in-t/u_number16", "65535");
+    auto & unumber16 = runner.create_datanode("ytypes/built-in-t/u_number16", "65535");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -389,18 +389,18 @@ TEST_CASE("test_sanity_types_uint16 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -427,7 +427,7 @@ TEST_CASE("test_sanity_types_uint32 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -439,12 +439,12 @@ TEST_CASE("test_sanity_types_uint32 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & unumber32 = runner.create("ytypes/built-in-t/u_number32", "5927");
+    auto & unumber32 = runner.create_datanode("ytypes/built-in-t/u_number32", "5927");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -454,18 +454,18 @@ TEST_CASE("test_sanity_types_uint32 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -492,7 +492,7 @@ TEST_CASE("test_sanity_types_uint64 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -504,12 +504,12 @@ TEST_CASE("test_sanity_types_uint64 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & unumber64 = runner.create("ytypes/built-in-t/u_number64", "18446744073709551615");
+    auto & unumber64 = runner.create_datanode("ytypes/built-in-t/u_number64", "18446744073709551615");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -517,18 +517,18 @@ TEST_CASE("test_sanity_types_uint64 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -557,7 +557,7 @@ TEST_CASE("test_sanity_types_bits ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -569,12 +569,12 @@ TEST_CASE("test_sanity_types_bits ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & bits = runner.create("ytypes/built-in-t/bits-value", "disable-nagle");
+    auto & bits = runner.create_datanode("ytypes/built-in-t/bits-value", "disable-nagle");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -583,18 +583,18 @@ TEST_CASE("test_sanity_types_bits ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -621,7 +621,7 @@ TEST_CASE("test_sanity_types_decimal64 ")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -633,12 +633,12 @@ TEST_CASE("test_sanity_types_decimal64 ")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & deci64 = runner.create("ytypes/built-in-t/deci64", "2.14");
+    auto & deci64 = runner.create_datanode("ytypes/built-in-t/deci64", "2.14");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -646,18 +646,18 @@ TEST_CASE("test_sanity_types_decimal64 ")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -687,7 +687,7 @@ TEST_CASE("test_sanity_types_string")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -699,12 +699,12 @@ TEST_CASE("test_sanity_types_string")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & str = runner.create("ytypes/built-in-t/name", "name_str");
+    auto & str = runner.create_datanode("ytypes/built-in-t/name", "name_str");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -712,18 +712,18 @@ TEST_CASE("test_sanity_types_string")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -752,7 +752,7 @@ TEST_CASE("test_sanity_types_empty")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -764,12 +764,12 @@ TEST_CASE("test_sanity_types_empty")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & emptee = runner.create("ytypes/built-in-t/emptee", "");
+    auto & emptee = runner.create_datanode("ytypes/built-in-t/emptee", "");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -777,18 +777,18 @@ TEST_CASE("test_sanity_types_empty")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -815,7 +815,7 @@ TEST_CASE("test_sanity_types_boolean")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -827,12 +827,12 @@ TEST_CASE("test_sanity_types_boolean")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & bool_val = runner.create("ytypes/built-in-t/bool-value", "true");
+    auto & bool_val = runner.create_datanode("ytypes/built-in-t/bool-value", "true");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -840,18 +840,18 @@ TEST_CASE("test_sanity_types_boolean")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -879,7 +879,7 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -891,12 +891,12 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & embedded_enum = runner.create("ytypes/built-in-t/embeded-enum", "zero");
+    auto & embedded_enum = runner.create_datanode("ytypes/built-in-t/embeded-enum", "zero");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -904,18 +904,18 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -942,7 +942,7 @@ TEST_CASE("test_sanity_types_enum")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -954,12 +954,12 @@ TEST_CASE("test_sanity_types_enum")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & enum_value = runner.create("ytypes/built-in-t/enum-value", "none");
+    auto & enum_value = runner.create_datanode("ytypes/built-in-t/enum-value", "none");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -967,18 +967,18 @@ TEST_CASE("test_sanity_types_enum")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1006,7 +1006,7 @@ TEST_CASE("test_sanity_types_union")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -1018,12 +1018,12 @@ TEST_CASE("test_sanity_types_union")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & union_value = runner.create("ytypes/built-in-t/younion", "none");
+    auto & union_value = runner.create_datanode("ytypes/built-in-t/younion", "none");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1031,18 +1031,18 @@ TEST_CASE("test_sanity_types_union")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1070,7 +1070,7 @@ TEST_CASE("test_sanity_types_union_enum")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -1082,12 +1082,12 @@ TEST_CASE("test_sanity_types_union_enum")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & enum_int_value = runner.create("ytypes/built-in-t/enum-int-value", "any");
+    auto & enum_int_value = runner.create_datanode("ytypes/built-in-t/enum-int-value", "any");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1095,18 +1095,18 @@ TEST_CASE("test_sanity_types_union_enum")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1136,7 +1136,7 @@ TEST_CASE("test_sanity_types_union_int")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -1148,12 +1148,12 @@ TEST_CASE("test_sanity_types_union_int")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & enum_int_value = runner.create("ytypes/built-in-t/enum-int-value", "2");
+    auto & enum_int_value = runner.create_datanode("ytypes/built-in-t/enum-int-value", "2");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1162,18 +1162,18 @@ TEST_CASE("test_sanity_types_union_int")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1202,7 +1202,7 @@ TEST_CASE("test_union_leaflist")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -1214,14 +1214,14 @@ TEST_CASE("test_union_leaflist")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & llunion1 = runner.create("ytypes/built-in-t/llunion[.='1']", "");
+    auto & llunion1 = runner.create_datanode("ytypes/built-in-t/llunion[.='1']", "");
 
-    auto & llunion2 = runner.create("ytypes/built-in-t/llunion[.='2']", "");
+    auto & llunion2 = runner.create_datanode("ytypes/built-in-t/llunion[.='2']", "");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1229,18 +1229,18 @@ TEST_CASE("test_union_leaflist")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1267,7 +1267,7 @@ TEST_CASE("test_enum_leaflist")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -1279,14 +1279,14 @@ TEST_CASE("test_enum_leaflist")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & local = runner.create("ytypes/built-in-t/enum-llist[.='local']", "");
+    auto & local = runner.create_datanode("ytypes/built-in-t/enum-llist[.='local']", "");
 
-    auto & remote = runner.create("ytypes/built-in-t/enum-llist[.='remote']", "");
+    auto & remote = runner.create_datanode("ytypes/built-in-t/enum-llist[.='remote']", "");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1294,18 +1294,18 @@ TEST_CASE("test_enum_leaflist")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1332,7 +1332,7 @@ TEST_CASE("test_identity_leaflist")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -1344,14 +1344,14 @@ TEST_CASE("test_identity_leaflist")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & child_identity = runner.create("ytypes/built-in-t/identity-llist[.='ydktest-sanity:child-identity']", "");
+    auto & child_identity = runner.create_datanode("ytypes/built-in-t/identity-llist[.='ydktest-sanity:child-identity']", "");
 
-    auto & child_child_identity = runner.create("ytypes/built-in-t/identity-llist[.='ydktest-sanity:child-child-identity']", "");
+    auto & child_child_identity = runner.create_datanode("ytypes/built-in-t/identity-llist[.='ydktest-sanity:child-child-identity']", "");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1359,18 +1359,18 @@ TEST_CASE("test_identity_leaflist")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1398,7 +1398,7 @@ TEST_CASE("test_union_complex_list")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -1410,12 +1410,12 @@ TEST_CASE("test_union_complex_list")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & younion = runner.create("ytypes/built-in-t/younion-list[.='123:45']", "");
+    auto & younion = runner.create_datanode("ytypes/built-in-t/younion-list[.='123:45']", "");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1423,18 +1423,18 @@ TEST_CASE("test_union_complex_list")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 
@@ -1457,7 +1457,7 @@ TEST_CASE("test_identityref")
 
     ydk::path::Codec s{};
 
-    auto & runner = schema.create("ydktest-sanity:runner", "");
+    auto & runner = schema.create_datanode("ydktest-sanity:runner", "");
 
     //get the root
     const ydk::path::DataNode* data_root = reinterpret_cast<const ydk::path::DataNode*>(&runner.get_root());
@@ -1469,12 +1469,12 @@ TEST_CASE("test_identityref")
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
-    delete_rpc->input().create("entity", xml);
+    delete_rpc->input().create_datanode("entity", xml);
 
     //call delete
     (*delete_rpc)(sp);
 
-    auto & identity_ref_value = runner.create("ytypes/built-in-t/identity-ref-value", "ydktest-sanity:child-child-identity");
+    auto & identity_ref_value = runner.create_datanode("ytypes/built-in-t/identity-ref-value", "ydktest-sanity:child-child-identity");
 
     xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1482,18 +1482,18 @@ TEST_CASE("test_identityref")
 
     //call create
     std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
-    create_rpc->input().create("entity", xml);
+    create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
     std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
-    auto & runner_read = schema.create("ydktest-sanity:runner", "");
+    auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
 
     xml = s.encode(runner_read, ydk::EncodingFormat::XML, false);
     REQUIRE( !xml.empty() );
-    read_rpc->input().create("filter", xml);
+    read_rpc->input().create_datanode("filter", xml);
 
     auto read_result = (*read_rpc)(sp);
 

--- a/sdk/cpp/tests/testsanitynctest.cpp
+++ b/sdk/cpp/tests/testsanitynctest.cpp
@@ -48,7 +48,7 @@ TEST_CASE("test_sanity_types_int8 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -65,12 +65,12 @@ TEST_CASE("test_sanity_types_int8 ")
 
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -114,7 +114,7 @@ TEST_CASE("test_sanity_types_int16 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -132,12 +132,12 @@ TEST_CASE("test_sanity_types_int16 ")
 
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -181,7 +181,7 @@ TEST_CASE("test_sanity_types_int32 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -197,12 +197,12 @@ TEST_CASE("test_sanity_types_int32 ")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -244,7 +244,7 @@ TEST_CASE("test_sanity_types_int64 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -260,12 +260,12 @@ TEST_CASE("test_sanity_types_int64 ")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -307,7 +307,7 @@ TEST_CASE("test_sanity_types_uint8 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -324,12 +324,12 @@ TEST_CASE("test_sanity_types_uint8 ")
 
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -371,7 +371,7 @@ TEST_CASE("test_sanity_types_uint16 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -388,12 +388,12 @@ TEST_CASE("test_sanity_types_uint16 ")
                         );
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -435,7 +435,7 @@ TEST_CASE("test_sanity_types_uint32 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -453,12 +453,12 @@ TEST_CASE("test_sanity_types_uint32 ")
 
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -500,7 +500,7 @@ TEST_CASE("test_sanity_types_uint64 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -516,12 +516,12 @@ TEST_CASE("test_sanity_types_uint64 ")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -565,7 +565,7 @@ TEST_CASE("test_sanity_types_bits ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -582,12 +582,12 @@ TEST_CASE("test_sanity_types_bits ")
 
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -629,7 +629,7 @@ TEST_CASE("test_sanity_types_decimal64 ")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -645,12 +645,12 @@ TEST_CASE("test_sanity_types_decimal64 ")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -695,7 +695,7 @@ TEST_CASE("test_sanity_types_string")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -711,12 +711,12 @@ TEST_CASE("test_sanity_types_string")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -760,7 +760,7 @@ TEST_CASE("test_sanity_types_empty")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -776,12 +776,12 @@ TEST_CASE("test_sanity_types_empty")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -823,7 +823,7 @@ TEST_CASE("test_sanity_types_boolean")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -839,12 +839,12 @@ TEST_CASE("test_sanity_types_boolean")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -887,7 +887,7 @@ TEST_CASE("test_sanity_types_embedded_enum")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -903,12 +903,12 @@ TEST_CASE("test_sanity_types_embedded_enum")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -950,7 +950,7 @@ TEST_CASE("test_sanity_types_enum")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -966,12 +966,12 @@ TEST_CASE("test_sanity_types_enum")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -1014,7 +1014,7 @@ TEST_CASE("test_sanity_types_union")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1030,12 +1030,12 @@ TEST_CASE("test_sanity_types_union")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -1078,7 +1078,7 @@ TEST_CASE("test_sanity_types_union_enum")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1094,12 +1094,12 @@ TEST_CASE("test_sanity_types_union_enum")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -1144,7 +1144,7 @@ TEST_CASE("test_sanity_types_union_int")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1161,12 +1161,12 @@ TEST_CASE("test_sanity_types_union_int")
 
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -1210,7 +1210,7 @@ TEST_CASE("test_union_leaflist")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1228,12 +1228,12 @@ TEST_CASE("test_union_leaflist")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -1275,7 +1275,7 @@ TEST_CASE("test_enum_leaflist")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1293,12 +1293,12 @@ TEST_CASE("test_enum_leaflist")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -1340,7 +1340,7 @@ TEST_CASE("test_identity_leaflist")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1358,12 +1358,12 @@ TEST_CASE("test_identity_leaflist")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -1406,7 +1406,7 @@ TEST_CASE("test_union_complex_list")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1422,12 +1422,12 @@ TEST_CASE("test_union_complex_list")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());
@@ -1465,7 +1465,7 @@ TEST_CASE("test_identityref")
     REQUIRE( data_root != nullptr );
 
     //first delete
-    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.rpc("ydk:delete") };
+    std::shared_ptr<ydk::path::Rpc> delete_rpc { schema.create_rpc("ydk:delete") };
 
     auto xml = s.encode(runner, ydk::EncodingFormat::XML, false);
 
@@ -1481,12 +1481,12 @@ TEST_CASE("test_identityref")
     CHECK( !xml.empty());
 
     //call create
-    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.rpc("ydk:create") };
+    std::shared_ptr<ydk::path::Rpc> create_rpc { schema.create_rpc("ydk:create") };
     create_rpc->input().create_datanode("entity", xml);
     (*create_rpc)(sp);
 
     //call read
-    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.rpc("ydk:read") };
+    std::shared_ptr<ydk::path::Rpc> read_rpc { schema.create_rpc("ydk:read") };
     auto & runner_read = schema.create_datanode("ydktest-sanity:runner", "");
 
     const ydk::path::DataNode* data_root2 = reinterpret_cast<const ydk::path::DataNode*>(&runner_read.get_root());

--- a/sdk/cpp/tests/testsanitynctest.cpp
+++ b/sdk/cpp/tests/testsanitynctest.cpp
@@ -90,7 +90,7 @@ TEST_CASE("test_sanity_types_int8 ")
 
     auto number8_read = number8_read_vec[0];
 
-    REQUIRE(number8.get() == number8_read->get() );
+    REQUIRE(number8.get_value() == number8_read->get_value() );
 
 
 }
@@ -157,7 +157,7 @@ TEST_CASE("test_sanity_types_int16 ")
 
     auto & number16_read = number16_read_vec[0];
 
-    REQUIRE(number16.get() == number16_read->get() );
+    REQUIRE(number16.get_value() == number16_read->get_value() );
 
 
 }
@@ -221,7 +221,7 @@ TEST_CASE("test_sanity_types_int32 ")
 
     auto number32_read = number32_read_vec[0];
 
-    REQUIRE(number32.get() == number32_read->get() );
+    REQUIRE(number32.get_value() == number32_read->get_value() );
 
 }
 
@@ -284,7 +284,7 @@ TEST_CASE("test_sanity_types_int64 ")
 
     auto number64_read = number64_read_vec[0];
 
-    REQUIRE(number64.get() == number64_read->get() );
+    REQUIRE(number64.get_value() == number64_read->get_value() );
 
 }
 
@@ -348,7 +348,7 @@ TEST_CASE("test_sanity_types_uint8 ")
 
     auto unumber8_read = unumber8_read_vec[0];
 
-    REQUIRE(unumber8.get() == unumber8_read->get() );
+    REQUIRE(unumber8.get_value() == unumber8_read->get_value() );
 
 }
 
@@ -412,7 +412,7 @@ TEST_CASE("test_sanity_types_uint16 ")
 
     auto unumber16_read = unumber16_read_vec[0];
 
-    REQUIRE(unumber16.get() == unumber16_read->get() );
+    REQUIRE(unumber16.get_value() == unumber16_read->get_value() );
 
 }
 
@@ -477,7 +477,7 @@ TEST_CASE("test_sanity_types_uint32 ")
 
     auto unumber32_read = unumber32_read_vec[0];
 
-    REQUIRE(unumber32.get() == unumber32_read->get() );
+    REQUIRE(unumber32.get_value() == unumber32_read->get_value() );
 
 }
 
@@ -540,7 +540,7 @@ TEST_CASE("test_sanity_types_uint64 ")
 
     auto unumber64_read = unumber64_read_vec[0];
 
-    REQUIRE(unumber64.get() == unumber64_read->get() );
+    REQUIRE(unumber64.get_value() == unumber64_read->get_value() );
 
 
 }
@@ -606,7 +606,7 @@ TEST_CASE("test_sanity_types_bits ")
 
     auto bits_read = bits_read_vec[0];
 
-    REQUIRE(bits.get() == bits_read->get() );
+    REQUIRE(bits.get_value() == bits_read->get_value() );
 
 }
 
@@ -670,9 +670,9 @@ TEST_CASE("test_sanity_types_decimal64 ")
     auto deci64_read = deci64_read_vec[0];
 
     //TODO log this
-    //std::cout << deci64_read->get() << std::endl;
+    //std::cout << deci64_read->get_value() << std::endl;
 
-    REQUIRE(deci64.get() == deci64_read->get() );
+    REQUIRE(deci64.get_value() == deci64_read->get_value() );
 
 }
 
@@ -735,9 +735,9 @@ TEST_CASE("test_sanity_types_string")
 
     auto str_read = str_read_vec[0];
 
-    //std::cout << str_read->get() << std::endl;
+    //std::cout << str_read->get_value() << std::endl;
 
-    REQUIRE(str.get() == str_read->get() );
+    REQUIRE(str.get_value() == str_read->get_value() );
 
 }
 
@@ -863,7 +863,7 @@ TEST_CASE("test_sanity_types_boolean")
 
     auto bool_val_read = bool_val_read_vec[0];
 
-    REQUIRE(bool_val.get() == bool_val_read->get() );
+    REQUIRE(bool_val.get_value() == bool_val_read->get_value() );
 
 }
 
@@ -927,7 +927,7 @@ TEST_CASE("test_sanity_types_embedded_enum")
 
     auto embedded_enum_read = embedded_enum_read_vec[0];
 
-    REQUIRE(embedded_enum.get() == embedded_enum_read->get() );
+    REQUIRE(embedded_enum.get_value() == embedded_enum_read->get_value() );
 
 }
 
@@ -991,7 +991,7 @@ TEST_CASE("test_sanity_types_enum")
     auto enum_value_read = enum_value_read_vec[0];
 
 
-    REQUIRE(enum_value.get() == enum_value_read->get() );
+    REQUIRE(enum_value.get_value() == enum_value_read->get_value() );
 
 }
 
@@ -1054,7 +1054,7 @@ TEST_CASE("test_sanity_types_union")
 
     auto union_value_read = union_value_read_vec[0];
 
-    REQUIRE(union_value.get() == union_value_read->get() );
+    REQUIRE(union_value.get_value() == union_value_read->get_value() );
 
 
 }
@@ -1120,7 +1120,7 @@ TEST_CASE("test_sanity_types_union_enum")
     auto enum_int_value_read = enum_int_value_read_vec[0];
 
 
-    REQUIRE(enum_int_value.get() == enum_int_value_read->get() );
+    REQUIRE(enum_int_value.get_value() == enum_int_value_read->get_value() );
 
 
 }
@@ -1186,7 +1186,7 @@ TEST_CASE("test_sanity_types_union_int")
 
     auto enum_int_value_read = enum_int_value_read_vec[0];
 
-    REQUIRE(enum_int_value.get() == enum_int_value_read->get() );
+    REQUIRE(enum_int_value.get_value() == enum_int_value_read->get_value() );
 
 }
 
@@ -1503,7 +1503,7 @@ TEST_CASE("test_identityref")
 
     REQUIRE(!identityref_value_read_vec.empty());
 
-    auto val = identityref_value_read_vec[0]->get();
+    auto val = identityref_value_read_vec[0]->get_value();
     //std::cout <<  val << std::endl;
 
     REQUIRE(val == "ydktest-sanity:child-child-identity");

--- a/sdk/python/core/docsgen/api/path/data_node.rst
+++ b/sdk/python/core/docsgen/api/path/data_node.rst
@@ -18,7 +18,7 @@ DataNode
             >>> from ydk.providers import NetconfServiceProvider
             >>> provider = NetconfServiceProvider('127.0.0.1', 'admin', 'admin', 830)
             >>> root_schema = provider.get_root_schema()                               # <-- root_schema is an instance of RootSchemaNode
-            >>> bgp = root_schema.create('openconfig-bgp:bgp')                         # <-- bgp is an instance of DataNode
+            >>> bgp = root_schema.create_datanode('openconfig-bgp:bgp')                         # <-- bgp is an instance of DataNode
 
 
     .. py:method:: add_annotation(annotation)
@@ -35,14 +35,14 @@ DataNode
         :return: List of annotations for this data node.
         :rtype: list of :py:class:`Annotation<ydk.path.Annotation>`
 
-    .. py:method:: children()
+    .. py:method:: get_children()
 
         Return list of children for this data node.
 
         :return: List of data node children.
         :rtype: list of :py:class:`DataNode<ydk.path.DataNode>`
 
-    .. py:method:: create(path, value=None)
+    .. py:method:: create_datanode(path, value=None)
 
         Create a DataNode corresponding to the path and set its value, if provided.
 
@@ -67,7 +67,7 @@ DataNode
         :return: Value of this data node.
         :rtype: A Python string
 
-    .. py:method:: path()
+    .. py:method:: get_path()
 
         Returns the path expression representing this Node in in the NodeTree.
 
@@ -82,18 +82,18 @@ DataNode
         :return: If ``True`` the annotation was found and removed, ``False`` otherwise.
         :rtype: bool
 
-    .. py:method:: root()
+    .. py:method:: get_root()
 
         Get the root data node.
 
         :return: Root data node of current data node.
         :rtype: :py:class:`~DataNode`
 
-    .. py:method:: schema()
+    .. py:method:: get_schema_node()
 
         Get :py:class:`SchemaNode` associated with this :py:class:`DataNode`.
 
-    .. py:method:: set(value)
+    .. py:method:: set_value(value)
 
         .. note::
 

--- a/sdk/python/core/docsgen/api/path/root_schema_node.rst
+++ b/sdk/python/core/docsgen/api/path/root_schema_node.rst
@@ -9,7 +9,7 @@ RootSchemaNode
 
     Instances of this class represent the ``Root`` of the ``SchemaTree``. A ``RootSchemaNode`` can be used to instantiate a ``DataNode`` tree or an ``Rpc`` object. The children of the ``RootSchemaNode`` represent the top level ``SchemaNode`` in the YANG module submodules.
 
-    .. py:method:: create(path, value=None)
+    .. py:method:: create_datanode(path, value=None)
 
         Create data node with path and value.
         This methods creates a :py:class:`DataNode` tree based on the path passed in. The path expression must identify a single node. If the last node created is of schema type ``list``, ``leaf-list`` or ``anyxml`` that value is also set in the node.
@@ -31,28 +31,28 @@ RootSchemaNode
         :return: List of schema node satisfies the criterion.
         :rtype: list of :py:class:`SchemaNode`
 
-    .. py:method:: parent()
+    .. py:method:: get_parent()
 
         Get parent.
 
         :return: ``RootSchemaNode``'s parent, which is ``None``.
         :rtype: None
 
-    .. py:method:: path()
+    .. py:method:: get_path()
 
         Get path.
 
         :return: ``RootSchemaNode``'s path, which is ``\``.
         :rtype: A Python string
 
-    .. py:method:: root()
+    .. py:method:: get_root()
 
         Get the root schema node for ``RootSchemaNode``.
 
         :return: ``RootSchemaNode``'s Root schema node.
         :rtype: :py:class:`SchemaNode<ydk.path.SchemaNode>`
 
-    .. py:method:: rpc(path)
+    .. py:method:: create_rpc(path)
 
         Create an Rpc instance.
 
@@ -70,4 +70,4 @@ RootSchemaNode
             from ydk.providers import NetconfServiceProvider
             provider = NetconfServiceProvider('127.0.0.1', 'admin', 'admin')
             root_schema = provider.get_root_schema()
-            root_schema.rpc('ydk:create')
+            root_schema.create_rpc('ydk:create')

--- a/sdk/python/core/docsgen/api/path/rpc.rst
+++ b/sdk/python/core/docsgen/api/path/rpc.rst
@@ -18,14 +18,14 @@ Rpc
         :return: :py:class:`DataNode` instance if succeed.
         :rtype: None or :py:class:`DataNode`
 
-    .. py:method:: input()
+    .. py:method:: get_input_node()
 
         Get the input data tree.
 
         :return: :py:class:`DataNode` representing the input data tree or ``None`` if the rpc does not have an input element in the schema.
         :rtype: :py:class:`DataNode` or ``None``
 
-    .. py:method:: schema()
+    .. py:method:: get_schema_node()
 
         Get schema node for this rpc.
 

--- a/sdk/python/core/docsgen/api/path/schema_node.rst
+++ b/sdk/python/core/docsgen/api/path/schema_node.rst
@@ -18,8 +18,8 @@ SchemaNode
             >>> from ydk.providers import NetconfServiceProvider
             >>> provider = NetconfServiceProvider('127.0.0.1', 'admin', 'admin', 830)
             >>> root_schema = provider.get_root_schema()                               # <-- root_schema is an instance of RootSchemaNode
-            >>> bgp = root_schema.create('openconfig-bgp:bgp')                         # <-- bgp is an instance of DataNode
-            >>> schema_node = bgp.schema()                                             # <-- schema node for bgp
+            >>> bgp = root_schema.create_datanode('openconfig-bgp:bgp')                         # <-- bgp is an instance of DataNode
+            >>> schema_node = bgp.get_schema_node()                                             # <-- schema node for bgp
 
     .. py:method:: find(path)
 
@@ -31,28 +31,28 @@ SchemaNode
         :raises RuntimeError: With ``YCPPPathError`` prefix if the path expression in invalid, see error code for details.
         :raises RuntimeError: With ``YCPPInvalidArgumentError`` if the argument is invalid.
 
-    .. py:method:: parent()
+    .. py:method:: get_parent()
 
         Get the parent node of this schema node in the tree.
 
         :return: Parent schema node.
         :rtype: :py:class:`SchemaNode`
 
-    .. py:method:: path()
+    .. py:method:: get_path()
 
         Get the path expression representing this schema node in in the schema node tree.
 
         :return: Path to this schema node.
         :rtype: A Python string
 
-    .. py:method:: root()
+    .. py:method:: get_root()
 
         Get the root schema node of current schema node.
 
         :return: Root schema node of current schema node.
         :rtype: :py:class:`SchemaNode`
 
-    .. py:method:: statement()
+    .. py:method:: get_statement()
 
         Get current schema node's YANG statement.
 

--- a/sdk/python/core/docsgen/api/path/statement.rst
+++ b/sdk/python/core/docsgen/api/path/statement.rst
@@ -33,9 +33,9 @@ Statement
         >>> from ydk.providers import NetconfServiceProvider
         >>> provider = NetconfServiceProvider('127.0.0.1', 'admin', 'admin', 830)
         >>> root_schema = provider.get_root_schema()                               # <-- root_schema is an instance of RootSchemaNode
-        >>> bgp = root_schema.create('openconfig-bgp:bgp')                         # <-- bgp is an instance of DataNode
-        >>> schema_node = bgp.schema()                                             # <-- schema node for bgp
-        >>> statement = schema_node.statement()                                    # <-- YANG statement for this schema node
+        >>> bgp = root_schema.create_datanode('openconfig-bgp:bgp')                         # <-- bgp is an instance of DataNode
+        >>> schema_node = bgp.get_schema_node()                                             # <-- schema node for bgp
+        >>> statement = schema_node.get_statement()                                    # <-- YANG statement for this schema node
         >>> statement.keyword
         'container'
         >>> statement.arg

--- a/sdk/python/core/docsgen/guides/path.rst
+++ b/sdk/python/core/docsgen/guides/path.rst
@@ -71,22 +71,22 @@ Example for using Path API is shown below(assuming you have openconfig-bgp avaia
     provider = NetconfServiceProvider('127.0.0.1', 'admin', 'admin', 12022)
     root_schema = provider.get_root_schema()                                # get root schema node
 
-    bgp = root_schema.create("openconfig-bgp:bgp", "")
-    bgp.create("global/config/as", "65172")
-    l3vpn_ipv4_unicast = bgp.create("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "")
-    l3vpn_ipv4_unicast.create("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST")
-    l3vpn_ipv4_unicast.create("config/enabled","true")
-    neighbor = bgp.create("neighbors/neighbor[neighbor-address='172.16.255.2']", "")
-    neighbor.create("config/neighbor-address", "172.16.255.2")
-    neighbor.create("config/peer-as","65172")
-    neighbor_af = neighbor.create("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "")
-    neighbor_af.create("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST")
-    neighbor_af.create("config/enabled","true")
+    bgp = root_schema.create_datanode("openconfig-bgp:bgp", "")
+    bgp.create_datanode("global/config/as", "65172")
+    l3vpn_ipv4_unicast = bgp.create_datanode("global/afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "")
+    l3vpn_ipv4_unicast.create_datanode("config/afi-safi-name", "openconfig-bgp-types:L3VPN_IPV4_UNICAST")
+    l3vpn_ipv4_unicast.create_datanode("config/enabled","true")
+    neighbor = bgp.create_datanode("neighbors/neighbor[neighbor-address='172.16.255.2']", "")
+    neighbor.create_datanode("config/neighbor-address", "172.16.255.2")
+    neighbor.create_datanode("config/peer-as","65172")
+    neighbor_af = neighbor.create_datanode("afi-safis/afi-safi[afi-safi-name='openconfig-bgp-types:L3VPN_IPV4_UNICAST']", "")
+    neighbor_af.create_datanode("config/afi-safi-name" , "openconfig-bgp-types:L3VPN_IPV4_UNICAST")
+    neighbor_af.create_datanode("config/enabled","true")
 
     codec_service = Codec()
     xml = codec_service.encode(bgp, EncodingFormat.XML, True)               # get XML encoding
-    create_rpc = root_schema.rpc('ydk:create')
-    create_rpc.input().create('entity', xml)
+    create_rpc = root_schema.create_rpc('ydk:create')
+    create_rpc.get_input_node().create_datanode('entity', xml)
     create_rpc(provider)                                                    # create bgp configuration
 
     json = codec_service.encode(bgp, EncodingFormat.JSON, True)             # get JSON encoding

--- a/sdk/python/core/python.cpp
+++ b/sdk/python/core/python.cpp
@@ -281,46 +281,46 @@ PYBIND11_PLUGIN(ydk_)
         .def_readonly("arg", &ydk::path::Statement::arg);
 
     class_<ydk::path::SchemaNode, shared_ptr<ydk::path::SchemaNode>>(path, "SchemaNode")
-        .def("path", &ydk::path::SchemaNode::path)
-        .def("parent", &ydk::path::SchemaNode::parent)
-        .def("root", &ydk::path::SchemaNode::root, return_value_policy::reference)
-        .def("statement", &ydk::path::SchemaNode::statement, return_value_policy::reference)
+        .def("get_path", &ydk::path::SchemaNode::get_path)
+        .def("get_parent", &ydk::path::SchemaNode::get_parent)
+        .def("get_root", &ydk::path::SchemaNode::get_root, return_value_policy::reference)
+        .def("get_statement", &ydk::path::SchemaNode::get_statement, return_value_policy::reference)
         .def("find", &ydk::path::SchemaNode::find, return_value_policy::reference, arg("path"))
-        // .def("children", &ydk::path::SchemaNode::children)
-        .def("keys", &ydk::path::SchemaNode::keys, return_value_policy::reference);
+        // .def("get_children", &ydk::path::SchemaNode::get_children)
+        .def("get_keys", &ydk::path::SchemaNode::get_keys, return_value_policy::reference);
 
 
     class_<ydk::path::DataNode, shared_ptr<ydk::path::DataNode>>(path, "DataNode")
-        .def("schema", &ydk::path::DataNode::schema, return_value_policy::reference)
-        .def("path", &ydk::path::DataNode::path, return_value_policy::reference)
-        .def("create", (ydk::path::DataNode& (ydk::path::DataNode::*)(const string&)) &ydk::path::DataNode::create, return_value_policy::reference, arg("path"))
-        .def("create", (ydk::path::DataNode& (ydk::path::DataNode::*)(const string&, const string&)) &ydk::path::DataNode::create, return_value_policy::reference, arg("path"), arg("value"))
-        .def("get", &ydk::path::DataNode::get, return_value_policy::reference)
-        .def("set", &ydk::path::DataNode::set, return_value_policy::reference, arg("value"))
-        .def("children", &ydk::path::DataNode::children, return_value_policy::reference)
-        .def("root", &ydk::path::DataNode::root, return_value_policy::reference)
+        .def("get_schema_node", &ydk::path::DataNode::get_schema_node, return_value_policy::reference)
+        .def("get_path", &ydk::path::DataNode::get_path, return_value_policy::reference)
+        .def("create_datanode", (ydk::path::DataNode& (ydk::path::DataNode::*)(const string&)) &ydk::path::DataNode::create_datanode, return_value_policy::reference, arg("path"))
+        .def("create_datanode", (ydk::path::DataNode& (ydk::path::DataNode::*)(const string&, const string&)) &ydk::path::DataNode::create_datanode, return_value_policy::reference, arg("path"), arg("value"))
+        .def("get_value", &ydk::path::DataNode::get_value, return_value_policy::reference)
+        .def("set_value", &ydk::path::DataNode::set_value, return_value_policy::reference, arg("value"))
+        .def("get_children", &ydk::path::DataNode::get_children, return_value_policy::reference)
+        .def("get_root", &ydk::path::DataNode::get_root, return_value_policy::reference)
         .def("find", &ydk::path::DataNode::find, return_value_policy::reference, arg("path"))
         .def("add_annotation", &ydk::path::DataNode::add_annotation, return_value_policy::reference, arg("annotation"))
         .def("remove_annotation", &ydk::path::DataNode::remove_annotation, return_value_policy::reference, arg("annotation"))
         .def("annotations", &ydk::path::DataNode::annotations, return_value_policy::reference);
 
     class_<ydk::path::RootSchemaNode, shared_ptr<ydk::path::RootSchemaNode>>(path, "RootSchemaNode")
-        .def("path", &ydk::path::RootSchemaNode::path, return_value_policy::reference)
-        .def("parent", &ydk::path::RootSchemaNode::parent, return_value_policy::reference)
+        .def("get_path", &ydk::path::RootSchemaNode::get_path, return_value_policy::reference)
+        .def("get_parent", &ydk::path::RootSchemaNode::get_parent, return_value_policy::reference)
         .def("find", &ydk::path::RootSchemaNode::find, return_value_policy::reference)
-        .def("root", &ydk::path::RootSchemaNode::root, return_value_policy::reference)
-//      .def("children", &ydk::path::RootSchemaNode::children)
-        .def("create", (ydk::path::DataNode& (ydk::path::RootSchemaNode::*)(const string&)) &ydk::path::RootSchemaNode::create, return_value_policy::reference, arg("path"))
-        .def("create", (ydk::path::DataNode& (ydk::path::RootSchemaNode::*)(const string&, const string&)) &ydk::path::RootSchemaNode::create, return_value_policy::reference, arg("path"), arg("value"))
-        .def("rpc", &ydk::path::RootSchemaNode::rpc, arg("path"), return_value_policy::reference);
+        .def("get_root", &ydk::path::RootSchemaNode::get_root, return_value_policy::reference)
+//      .def("get_children", &ydk::path::RootSchemaNode::get_children)
+        .def("create_datanode", (ydk::path::DataNode& (ydk::path::RootSchemaNode::*)(const string&)) &ydk::path::RootSchemaNode::create_datanode, return_value_policy::reference, arg("path"))
+        .def("create_datanode", (ydk::path::DataNode& (ydk::path::RootSchemaNode::*)(const string&, const string&)) &ydk::path::RootSchemaNode::create_datanode, return_value_policy::reference, arg("path"), arg("value"))
+        .def("create_rpc", &ydk::path::RootSchemaNode::create_rpc, arg("path"), return_value_policy::reference);
 
     class_<ydk::path::ServiceProvider>(path, "ServiceProvider")
         .def("invoke", &ydk::path::ServiceProvider::invoke, return_value_policy::reference)
         .def("get_root_schema", &ydk::path::ServiceProvider::get_root_schema, return_value_policy::reference);
 
     class_<ydk::path::Rpc, shared_ptr<ydk::path::Rpc>>(path, "Rpc")
-        .def("schema", &ydk::path::Rpc::schema, return_value_policy::reference)
-        .def("input", &ydk::path::Rpc::input, return_value_policy::reference)
+        .def("get_schema_node", &ydk::path::Rpc::get_schema_node, return_value_policy::reference)
+        .def("get_input_node", &ydk::path::Rpc::get_input_node, return_value_policy::reference)
         .def("__call__", &ydk::path::Rpc::operator(), arg("service_provider"));
 
     class_<ydk::path::Repository>(path, "Repository")

--- a/sdk/python/core/samples/path_bgp.py
+++ b/sdk/python/core/samples/path_bgp.py
@@ -15,22 +15,22 @@
 # limitations under the License.
 # ------------------------------------------------------------------
 
-from ydk.providers import RestconfServiceProvider 
+from ydk.providers import RestconfServiceProvider
 from ydk.path import Codec, Repository
 from ydk.types import EncodingFormat
 
 
 def execute_path(provider, codec):
     schema = provider.get_root_schema()
-    bgp = schema.create("openconfig-bgp:bgp")
-    bgp.create("global/config/as", "65321")
+    bgp = schema.create_datanode("openconfig-bgp:bgp")
+    bgp.create_datanode("global/config/as", "65321")
 
-    runner = schema.create('ydktest-sanity:runner')
-    runner.create('ytypes/built-in-t/number8', '12')
+    runner = schema.create_datanode('ydktest-sanity:runner')
+    runner.create_datanode('ytypes/built-in-t/number8', '12')
     xml = codec.encode(runner, EncodingFormat.JSON, True)
     print(xml)
-    create_rpc = schema.rpc("ydk:create")
-    create_rpc.input().create("entity", xml)
+    create_rpc = schema.create_rpc("ydk:create")
+    create_rpc.get_input_node().create_datanode("entity", xml)
     create_rpc(provider)
 
 

--- a/sdk/python/core/samples/path_odl_bgp.py
+++ b/sdk/python/core/samples/path_odl_bgp.py
@@ -22,12 +22,12 @@ from ydk_.types import EncodingFormat
 
 def run(codec, provider):
     schema = provider.get_root_schema()
-    bgp = schema.create("openconfig-bgp:bgp")
-    bgp.create("global/config/as", "65321")
+    bgp = schema.create_datanode("openconfig-bgp:bgp")
+    bgp.create_datanode("global/config/as", "65321")
 
     xml = codec.encode(bgp, EncodingFormat.XML, True)
-    create_rpc = schema.rpc("ydk:create")
-    create_rpc.input().create("entity", xml)
+    create_rpc = schema.create_rpc("ydk:create")
+    create_rpc.get_input_node().create_datanode("entity", xml)
     create_rpc(provider)
 
 
@@ -37,4 +37,3 @@ if __name__ == "__main__":
     provider = o.get_node_provider('xr')
     codec = Codec()
     run(codec, provider)
-

--- a/sdk/python/core/tests/test_restconf_provider.py
+++ b/sdk/python/core/tests/test_restconf_provider.py
@@ -52,38 +52,38 @@ class SanityTest(unittest.TestCase):
 
     def test_create_del_read(self):
         root_schema = self.restconf_provider.get_root_schema()
-        runner = root_schema.create('ydktest-sanity:runner', '')
+        runner = root_schema.create_datanode('ydktest-sanity:runner', '')
 
-        delete_rpc = root_schema.rpc('ydk:delete')
+        delete_rpc = root_schema.create_rpc('ydk:delete')
         codec_service = Codec()
 
         json = codec_service.encode(runner, EncodingFormat.JSON, False)
-        delete_rpc.input().create('entity', json)
+        delete_rpc.get_input_node().create_datanode('entity', json)
         delete_rpc(self.restconf_provider)
 
-        number8 = runner.create('ytypes/built-in-t/number8', '3')
+        number8 = runner.create_datanode('ytypes/built-in-t/number8', '3')
         json = codec_service.encode(runner, EncodingFormat.JSON, False)
         self.assertNotEqual(json, '')
-        create_rpc = root_schema.rpc('ydk:create')
-        create_rpc.input().create('entity', json)
+        create_rpc = root_schema.create_rpc('ydk:create')
+        create_rpc.get_input_node().create_datanode('entity', json)
 
-        read_rpc = root_schema.rpc('ydk:read')
-        runner_read = root_schema.create('ydktest-sanity:runner', '')
+        read_rpc = root_schema.create_rpc('ydk:read')
+        runner_read = root_schema.create_datanode('ydktest-sanity:runner', '')
 
         json = codec_service.encode(runner_read, EncodingFormat.JSON, False)
         self.assertNotEqual(json, '')
-        read_rpc.input().create('filter', json)
+        read_rpc.get_input_node().create_datanode('filter', json)
 
         read_result = read_rpc(self.restconf_provider)
 
-        runner = root_schema.create('ydktest-sanity:runner', '')
-        number8 = runner.create('ytypes/built-in-t/number8', '5')
+        runner = root_schema.create_datanode('ydktest-sanity:runner', '')
+        number8 = runner.create_datanode('ytypes/built-in-t/number8', '5')
 
         json = codec_service.encode(runner, EncodingFormat.JSON, False)
         self.assertNotEqual(json, '')
 
-        update_rpc = root_schema.rpc('ydk:update')
-        update_rpc.input().create('entity', json)
+        update_rpc = root_schema.create_rpc('ydk:update')
+        update_rpc.get_input_node().create_datanode('entity', json)
         update_rpc(self.restconf_provider)
 
 

--- a/sdk/python/core/tests/test_sanity_path.py
+++ b/sdk/python/core/tests/test_sanity_path.py
@@ -30,10 +30,10 @@ class SanityTest(unittest.TestCase):
         self.codec = Codec()
 
     def _delete_runner(self):
-        runner = self.root_schema.create("ydktest-sanity:runner")
+        runner = self.root_schema.create_datanode("ydktest-sanity:runner")
         xml = self.codec.encode(runner, EncodingFormat.XML, True)
-        create_rpc = self.root_schema.rpc("ydk:delete")
-        create_rpc.input().create("entity", xml)
+        create_rpc = self.root_schema.create_rpc("ydk:delete")
+        create_rpc.get_input_node().create_datanode("entity", xml)
         create_rpc(self.ncc)
 
     def tearDown(self):
@@ -50,19 +50,19 @@ class SanityTest(unittest.TestCase):
                             ("ytypes/built-in-t/enum-llist[.='local']", ""),
                             ("ytypes/built-in-t/enum-llist[.='remote']", ""),
                             ("ytypes/built-in-t/younion-recursive", "18")]
-        runner = self.root_schema.create("ydktest-sanity:runner")
+        runner = self.root_schema.create_datanode("ydktest-sanity:runner")
         for (leaf_path, leaf_value) in leaf_path_values:
-            runner.create(leaf_path, leaf_value)
+            runner.create_datanode(leaf_path, leaf_value)
 
         xml = self.codec.encode(runner, EncodingFormat.XML, True)
-        create_rpc = self.root_schema.rpc("ydk:create")
-        create_rpc.input().create("entity", xml)
+        create_rpc = self.root_schema.create_rpc("ydk:create")
+        create_rpc.get_input_node().create_datanode("entity", xml)
         create_rpc(self.ncc)
 
-        runner_filter = self.root_schema.create("ydktest-sanity:runner")
+        runner_filter = self.root_schema.create_datanode("ydktest-sanity:runner")
         xml_filter = self.codec.encode(runner_filter, EncodingFormat.XML, False)
-        read_rpc = self.root_schema.rpc("ydk:read")
-        read_rpc.input().create("filter", xml_filter)
+        read_rpc = self.root_schema.create_rpc("ydk:read")
+        read_rpc.get_input_node().create_datanode("filter", xml_filter)
         runner_read = read_rpc(self.ncc)
         xml_read = self.codec.encode(runner_read, EncodingFormat.XML, True)
         self.maxDiff = None

--- a/sdk/python/core/ydk/services/codec_service.py
+++ b/sdk/python/core/ydk/services/codec_service.py
@@ -162,11 +162,11 @@ class CodecService(object):
         codec_service = _Codec()
         root_data_node = codec_service.decode(root_schema, payload, provider.encoding)
 
-        if len(root_data_node.children()) != 1:
+        if len(root_data_node.get_children()) != 1:
             self.logger.debug(_PAYLOAD_ERROR_MSG)
             raise _YPYServiceProviderError(_PAYLOAD_ERROR_MSG)
         else:
-            for data_node in root_data_node.children():
+            for data_node in root_data_node.get_children():
                 _get_entity_from_data_node(data_node, entity)
         return entity
 


### PR DESCRIPTION
- parent() --> get_parent()
- children() --> get_children()
- root() --> get_root()
- path() --> get_path()
- statement() --> get_statement()
- keys() --> get_keys()
- create() --> create_datanode()
- rpc() --> create_rpc()
- schema() --> get_schema_node()
- set() --> set_value()
- get() --> get_value()
- input() --> get_input_node()