### PR TITLE
YFilter

### DIFF
--- a/sdk/cpp/core/src/ydk.cpp
+++ b/sdk/cpp/core/src/ydk.cpp
@@ -657,13 +657,16 @@ DataNodeChildren DataNodeGetChildren(DataNode datanode)
     DataNodeWrapper* datanode_wrapper = (DataNodeWrapper*)datanode;
     ydk::path::DataNode* real_datanode = unwrap(datanode_wrapper);
 
-    std::vector<shared_ptr<ydk::path::DataNode>> children = real_datanode->children();
-    DataNode* child_array = new DataNode[children.size()];
-    for(size_t i=0; i < children.size(); i++)
-    {
-        child_array[i] = wrap(children[i]);
+    if (real_datanode != nullptr) {
+        std::vector<shared_ptr<ydk::path::DataNode>> children = real_datanode->children();
+        DataNode* child_array = new DataNode[children.size()];
+        for(size_t i=0; i < children.size(); i++)
+        {
+            child_array[i] = wrap(children[i]);
+        }
+        return {child_array, static_cast<int>(children.size())};
     }
-    return {child_array, static_cast<int>(children.size())};
+    return {nullptr, 0};
 }
 
 void DataNodeAddAnnotation(DataNode datanode, const char* operation)

--- a/sdk/go/core/tests/crud_test.go
+++ b/sdk/go/core/tests/crud_test.go
@@ -46,7 +46,7 @@ func (suite *NETCONFTestSuite) TestTemplate() {
 
 func (suite *NETCONFTestSuite) TestCreateRead() {
 	bgpCreate := ysanity_bgp.Bgp{}
-	bgpCreate.Global.Config.As = 65172 //types.Delete
+	bgpCreate.Global.Config.As = 65172
 	bgpCreate.Global.Config.RouterId = "1.2.3.4"
 
 	ipv6Afisafi := ysanity_bgp.Bgp_Global_AfiSafis_AfiSafi{}

--- a/sdk/go/core/tests/delete_test.go
+++ b/sdk/go/core/tests/delete_test.go
@@ -1,0 +1,296 @@
+package test
+
+import (
+	"fmt"
+	ysanity "github.com/CiscoDevNet/ydk-go/ydk/models/ydktest/sanity"
+	"github.com/CiscoDevNet/ydk-go/ydk/providers"
+	"github.com/CiscoDevNet/ydk-go/ydk/services"
+	"github.com/CiscoDevNet/ydk-go/ydk/types"
+	"github.com/stretchr/testify/suite"
+	"strconv"
+	"testing"
+)
+
+func getE(code int) ysanity.Runner_InbtwList_Ldata {
+	e := ysanity.Runner_InbtwList_Ldata{}
+	e.Number = code
+	e.Name = strconv.Itoa(code)
+	e.Subc.Number = code * 10
+	e.Subc.Name = strconv.Itoa(code * 10)
+	return e
+}
+
+func getEE(code int) ysanity.Runner_InbtwList_Ldata_Subc_SubcSubl1 {
+	ee := ysanity.Runner_InbtwList_Ldata_Subc_SubcSubl1{}
+	ee.Number = code
+	ee.Name = strconv.Itoa(code)
+	return ee
+}
+
+func getNestedObject() ysanity.Runner {
+	runner := ysanity.Runner{}
+
+	e1 := getE(1)
+	e2 := getE(2)
+
+	ee11 := getEE(11)
+	ee12 := getEE(12)
+
+	e1.Subc.SubcSubl1 = append(e1.Subc.SubcSubl1, ee11)
+	e1.Subc.SubcSubl1 = append(e1.Subc.SubcSubl1, ee12)
+
+	ee21 := getEE(21)
+	ee22 := getEE(22)
+
+	e2.Subc.SubcSubl1 = append(e2.Subc.SubcSubl1, ee21)
+	e2.Subc.SubcSubl1 = append(e2.Subc.SubcSubl1, ee22)
+
+	runner.InbtwList.Ldata = append(runner.InbtwList.Ldata, e1)
+	runner.InbtwList.Ldata = append(runner.InbtwList.Ldata, e2)
+
+	return runner
+}
+
+type DeleteTestSuite struct {
+	suite.Suite
+	Provider providers.NetconfServiceProvider
+	CRUD     services.CrudService
+}
+
+func (suite *DeleteTestSuite) SetupSuite() {
+	suite.CRUD = services.CrudService{}
+	suite.Provider = providers.NetconfServiceProvider{
+		Address:  "127.0.0.1",
+		Username: "admin",
+		Password: "admin",
+		Port:     12022}
+	suite.Provider.Connect()
+}
+
+func (suite *DeleteTestSuite) TearDownSuite() {
+	suite.Provider.Disconnect()
+}
+
+func (suite *DeleteTestSuite) BeforeTest(suiteName, testName string) {
+	suite.CRUD.Delete(&suite.Provider, &ysanity.Runner{})
+	fmt.Printf("%v: %v ...\n", suiteName, testName)
+}
+
+// func (suite *DeleteTestSuite) TestDeleteObjectOnLeaf() {
+// 	runnerCreate := ysanity.Runner{}
+// 	runnerCreate.One.Name = "runner.One.Name"
+// 	runnerCreate.Two.Name = "runner.Two.Name"
+// 	suite.CRUD.Create(&suite.Provider, &runnerCreate)
+
+// 	// Use YFilter Delete and CRUD update to remove leaf
+// 	runnerUpdate := ysanity.Runner{}
+// 	runnerUpdate.One.Name = types.Delete
+// 	suite.CRUD.Update(&suite.Provider, &runnerUpdate)
+
+// 	entityRead := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+// 	runnerCmp := ysanity.Runner{}
+// 	runnerCmp.Two.Name = "runner.Two.Name"
+
+// 	suite.Equal(types.EntityEqual(entityRead, &runnerCmp), true)
+// }
+
+// TODO: leaf-list encoding error
+// func (suite *DeleteTestSuite) TestDeleteOnLeafListSlice() {
+//     runnerCreate := ysanity.Runner{}
+//     runnerCreate.One.Name = "runner.One.Name"
+//     // TODO: leaf-list encoding error
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "1")
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "2")
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "3")
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "4")
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "5")
+//     suite.CRUD.Create(&suite.Provider, &runnerCreate)
+
+//     runnerUpdate := ysanity.Runner{}
+//     runnerUpdate.Ytypes.BuiltInT.Llstring = append(runnerUpdate.Ytypes.BuiltInT.Llstring, "1")
+//     runnerUpdate.Ytypes.BuiltInT.Llstring = append(runnerUpdate.Ytypes.BuiltInT.Llstring, "3")
+//     // TODO: leaf-list is declared as []interface, how to assign YFilter to them?
+//     runnerUpdate.Ytypes.BuiltInT.Llstring = types.Delete
+//     suite.CRUD.Update(&suite.Provider, &runnerUpdate)
+//     entityRead := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+
+//     runnerCmp := ysanity.Runner{}
+//     runnerCmp.One.Name = "runner.One.Name"
+//     runnerCmp.Ytypes.BuiltInT.Llstring = append(runnerCmp.Ytypes.BuiltInT.Llstring, "2")
+//     runnerCmp.Ytypes.BuiltInT.Llstring = append(runnerCmp.Ytypes.BuiltInT.Llstring, "4")
+//     runnerCmp.Ytypes.BuiltInT.Llstring = append(runnerCmp.Ytypes.BuiltInT.Llstring, "5")
+//     suite.Equal(types.EntityEqual(entityRead, &runnerCmp), true)
+// }
+
+// TODO: delete leaf from leaf-list
+// func (suite *DeleteTestSuite) TestDeleteOnLeafList() {
+//     runnerCreate := ysanity.Runner{}
+//     runnerCreate.One.Name = "runner.One.Name"
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "0")
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "1")
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "2")
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "3")
+//     runnerCreate.Ytypes.BuiltInT.Llstring = append(runnerCreate.Ytypes.BuiltInT.Llstring, "4")
+
+//     suite.CRUD.Create(&suite.Provider, &runnerCreate)
+
+//     runnerUpdate := ysanity.Runner{}
+//     // TODO: how to target a particular leaf from leaf-list using YFilter?
+//     runnerUpdate.Ytypes.BuiltInT.Llstring = append(runnerUpdate.Ytypes.BuiltInT.Llstring, "3")
+//     // runnerUpdate.Ytypes.BuiltInT.Llstring = types.Delete
+//     suite.CRUD.Update(&suite.Provider, &runnerUpdate)
+
+//     entityRead := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+
+//     runnerCmp := ysanity.Runner{}
+//     runnerCmp.One.Name = "runner.One.Name"
+//     runnerCmp.Ytypes.BuiltInT.Llstring = append(runnerCmp.Ytypes.BuiltInT.Llstring, "0")
+//     runnerCmp.Ytypes.BuiltInT.Llstring = append(runnerCmp.Ytypes.BuiltInT.Llstring, "1")
+//     runnerCmp.Ytypes.BuiltInT.Llstring = append(runnerCmp.Ytypes.BuiltInT.Llstring, "2")
+//     runnerCmp.Ytypes.BuiltInT.Llstring = append(runnerCmp.Ytypes.BuiltInT.Llstring, "4")
+
+//     suite.Equal(types.EntityEqual(entityRead, &runnerCmp), true)
+// }
+
+// func (suite *DeleteTestSuite) TestDeleteOnListWithIdentitykey() {
+// 	runner := ysanity.Runner{}
+// 	il := ysanity.Runner_OneList_IdentityList{}
+// 	il.Config.Id = ysanity.Child_Identity{}
+// 	il.IdRef = ysanity.Child_Identity{}
+
+// 	runner.OneList.IdentityList = append(runner.OneList.IdentityList, il)
+// 	suite.CRUD.Create(&suite.Provider, &runner)
+
+// 	runnerUpdate := ysanity.Runner{}
+// 	k := ysanity.Runner_OneList_IdentityList{}
+// 	k.Config.Id = ysanity.Child_Identity{}
+// 	k.IdRef = ysanity.Child_Identity{}
+// 	k.Filter = types.Delete
+// 	runnerUpdate.OneList.IdentityList = append(runnerUpdate.OneList.IdentityList, k)
+// 	suite.CRUD.Update(&suite.Provider, &runnerUpdate)
+
+// 	entityRead := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+
+// 	suite.Equal(types.EntityEqual(entityRead, &ysanity.Runner{}), true)
+// }
+
+// func (suite *DeleteTestSuite) TestDeleteOnContainer() {
+// 	runnerCreate := ysanity.Runner{}
+// 	runnerCreate.One.Name = "runner.One.Name"
+// 	runnerCreate.Two.Name = "runner.Two.Name"
+// 	suite.CRUD.Create(&suite.Provider, &runnerCreate)
+
+// 	runnerUpdate := ysanity.Runner{}
+// 	runnerUpdate.Two.Filter = types.Delete
+// 	suite.CRUD.Update(&suite.Provider, &runnerUpdate)
+
+// 	runnerCmp := ysanity.Runner{}
+// 	runnerCmp.One.Name = "runner.One.Name"
+
+// 	entityRead := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+
+// 	suite.Equal(types.EntityEqual(entityRead, &runnerCmp), true)
+// }
+
+// TODO: Delete whole list using YFilter
+// func (suite *DeleteTestSuite) TestDeleteOnNestedList() {
+// 	runnerCreate := getNestedObject()
+// 	fmt.Println(ee22)
+// 	suite.CRUD.Create(&suite.Provider, &runnerCreate)
+
+//     entity := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+//     runnerUpdate := entity.(*ysanity.Runner)
+
+//     // TODO: YANG list is printed as []interface, not able to assign YFilter Delete to YANG list
+//     runnerUpdate.InbtwList.Ldata[1].Subc.SubcSubl1 = types.Delete
+//     suite.CRUD.Update(&suite.Provider, runnerUpdate)
+
+//     entity = suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+//     runnerCmp := runnerCreate
+//     runnerCmp.InbtwList.Ldata[1].Subc.SubcSubl1 = runnerCmp.InbtwList.Ldata[1].Subc.SubcSubl1[:0]
+
+//     suite.Equal(types.EntityEqual(entity, &runnerCmp), true)
+// }
+
+func (suite *DeleteTestSuite) TestDeleteOnListElement() {
+	runnerCreate := getNestedObject()
+	suite.CRUD.Create(&suite.Provider, &runnerCreate)
+
+	runnerUpdate := runnerCreate
+	runnerUpdate.InbtwList.Ldata[1].Filter = types.Delete
+	suite.CRUD.Update(&suite.Provider, &runnerUpdate)
+
+	entity := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+
+	runnerCmp := runnerCreate
+	runnerCmp.InbtwList.Ldata = runnerCmp.InbtwList.Ldata[:1]
+
+	suite.Equal(types.EntityEqual(entity, &runnerCmp), true)
+}
+
+func (suite *DeleteTestSuite) TestDeleteOnListElements() {
+	runnerCreate := ysanity.Runner{}
+	runnerCreate.One.Name = "one"
+	foo := ysanity.Runner_OneList_Ldata{}
+	bar := ysanity.Runner_OneList_Ldata{}
+	baz := ysanity.Runner_OneList_Ldata{}
+	foo.Number = 1
+	foo.Name = "foo"
+	bar.Number = 2
+	bar.Name = "bar"
+	baz.Number = 3
+	baz.Name = "baz"
+
+	runnerCreate.OneList.Ldata = append(runnerCreate.OneList.Ldata, foo)
+	runnerCreate.OneList.Ldata = append(runnerCreate.OneList.Ldata, bar)
+	runnerCreate.OneList.Ldata = append(runnerCreate.OneList.Ldata, baz)
+
+	suite.CRUD.Create(&suite.Provider, &runnerCreate)
+
+	entity := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+	runnerUpdate := entity.(*ysanity.Runner)
+	runnerUpdate.OneList.Ldata[1].Filter = types.Delete
+	runnerUpdate.OneList.Ldata[2].Filter = types.Delete
+
+	suite.CRUD.Update(&suite.Provider, runnerUpdate)
+
+	entity = suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+
+	runnerCmp := runnerCreate
+	runnerCmp.OneList.Ldata = runnerCmp.OneList.Ldata[:1]
+
+	suite.Equal(types.EntityEqual(entity, &runnerCmp), true)
+}
+
+// TODO: Delete list using YFilter
+// func (suite *DeleteTestSuite) TestDeleteOnList() {
+//     runnerCreate := ysanity.Runner{}
+//     runnerCreate.One.Name = "one"
+//     foo := ysanity.Runner_OneList_Ldata{}
+//     bar := ysanity.Runner_OneList_Ldata{}
+//     foo.Number = 1
+//     foo.Name = "foo"
+//     bar.Number = 2
+//     bar.Name = "bar"
+
+//     runnerCreate.OneList.Ldata = append(runnerCreate.OneList.Ldata, foo)
+//     runnerCreate.OneList.Ldata = append(runnerCreate.OneList.Ldata, bar)
+
+//     suite.CRUD.Create(&suite.Provider, &runnerCreate)
+
+//     entity := suite.CRUD.Read(&suite.Provider, &ysanity.Runner{})
+//     runnerUpdate := entity.(*ysanity.Runner)
+
+//     // TODO: Delete whole list using YFilter
+//     // runnerUpdate.OneList.Ldata = types.Delete
+//     // suite.CRUD.Update(&suite.Provider, runnerUpdate)
+
+//     runnerCmp := runnerCreate
+//     runnerCmp.OneList.Ldata = runnerCmp.OneList.Ldata[:0]
+
+//     suite.Equal(types.EntityEqual(entity, &runnerCmp), true)
+// }
+
+func TestDeleteTestSuite(t *testing.T) {
+	suite.Run(t, new(DeleteTestSuite))
+}

--- a/sdk/go/core/tests/filter_read_test.go
+++ b/sdk/go/core/tests/filter_read_test.go
@@ -1,0 +1,198 @@
+package test
+
+import (
+	"fmt"
+	filterread "github.com/CiscoDevNet/ydk-go/ydk/models/ydktest/filterread"
+	"github.com/CiscoDevNet/ydk-go/ydk/providers"
+	"github.com/CiscoDevNet/ydk-go/ydk/services"
+	"github.com/CiscoDevNet/ydk-go/ydk/types"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+func getInitEntity() filterread.A {
+	a := filterread.A{}
+	a.A1 = "a.A1"
+	a.A2 = "a.A2"
+	a.A3 = "a.A3"
+	a.B.B1 = "a.B.B1"
+	a.B.B2 = "a.B.B2"
+	a.B.B3 = "a.B.B3"
+	a.B.F = filterread.A_B_F{}
+	a.B.F.F1 = "a.B.F.F1"
+	a.B.C = filterread.A_B_C{}
+	a.B.D.D1 = "a.B.D.D1"
+	a.B.D.D2 = "a.B.D.D2"
+	a.B.D.D3 = "a.B.D.D3"
+	a.B.D.E.E1 = "a.B.D.E.E1"
+	a.B.D.E.E2 = "a.B.D.E.E2"
+
+	l1 := filterread.A_Lst{}
+	l2 := filterread.A_Lst{}
+	l3 := filterread.A_Lst{}
+
+	l1.Number = 1
+	l1.Value = "l1.Value"
+
+	l2.Number = 2
+	l2.Value = "l2.Value"
+
+	l3.Number = 3
+	l3.Value = "l3.Value"
+
+	a.Lst = append(a.Lst, l1)
+	a.Lst = append(a.Lst, l2)
+	a.Lst = append(a.Lst, l3)
+
+	return a
+}
+
+type FilterReadTestSuite struct {
+	suite.Suite
+	Provider providers.NetconfServiceProvider
+	CRUD     services.CrudService
+}
+
+func (suite *FilterReadTestSuite) SetupSuite() {
+	suite.CRUD = services.CrudService{}
+	suite.Provider = providers.NetconfServiceProvider{
+		Address:  "127.0.0.1",
+		Username: "admin",
+		Password: "admin",
+		Port:     12022}
+	suite.Provider.Connect()
+
+	suite.CRUD.Delete(&suite.Provider, &filterread.A{})
+	initEntity := getInitEntity()
+	suite.CRUD.Create(&suite.Provider, &initEntity)
+}
+
+func (suite *FilterReadTestSuite) TearDownSuite() {
+	suite.Provider.Disconnect()
+}
+
+func (suite *FilterReadTestSuite) TearDownTest() {
+}
+
+// func (suite *FilterReadTestSuite) Test1() {
+// 	// Read on top container returns all data
+// 	a := filterread.A{}
+// 	entity := suite.CRUD.Read(&suite.Provider, &a)
+
+// 	initEntity := getInitEntity()
+// 	suite.Equal(types.EntityEqual(entity, &initEntity), true)
+// }
+
+// func (suite *FilterReadTestSuite) Test2() {
+// 	// According to https://tools.ietf.org/html/rfc6241#section-6.2.5,
+// 	// `a.A1` is a content match node. Reads on `a` returns all data.
+// 	a := filterread.A{}
+// 	a.A1 = "a.A1"
+// 	entity := suite.CRUD.Read(&suite.Provider, &a)
+
+// 	initEntity := getInitEntity()
+// 	suite.Equal(types.EntityEqual(entity, &initEntity), true)
+// }
+
+func (suite *FilterReadTestSuite) Test3() {
+	// Read on leaf
+	a := filterread.A{}
+	a.A1 = types.Read
+	entity := suite.CRUD.Read(&suite.Provider, &a)
+
+	initEntity := filterread.A{}
+	initEntity.A1 = "a.A1"
+	suite.Equal(types.EntityEqual(entity, &initEntity), true)
+}
+
+// func (suite *FilterReadTestSuite) Test4() {
+// 	// According to https://tools.ietf.org/html/rfc6241#section-6.2.5,
+// 	// `a.B.B1` is a content match node.
+// 	a := filterread.A{}
+// 	a.B.B1 = "a.B.B1"
+// 	entity := suite.CRUD.Read(&suite.Provider, &a)
+
+// 	initEntity := filterread.A{}
+// 	initEntity.B.B1 = "a.B.B1"
+// 	initEntity.B.B2 = "a.B.B2"
+// 	initEntity.B.B3 = "a.B.B3"
+
+// 	initEntity.B.F = filterread.A_B_F{}
+// 	initEntity.B.F.F1 = "a.B.F.F1"
+// 	initEntity.B.C = filterread.A_B_C{}
+// 	initEntity.B.D.D1 = "a.B.D.D1"
+// 	initEntity.B.D.D2 = "a.B.D.D2"
+// 	initEntity.B.D.D3 = "a.B.D.D3"
+// 	initEntity.B.D.E.E1 = "a.B.D.E.E1"
+// 	initEntity.B.D.E.E2 = "a.B.D.E.E2"
+
+// 	suite.Equal(types.EntityEqual(entity, &initEntity), true)
+// }
+
+// func (suite *FilterReadTestSuite) Test5() {
+// 	// According to https://tools.ietf.org/html/rfc6241#section-6.2.5,
+// 	// `a.B.D.E.E1` is a content match node.
+// 	a := filterread.A{}
+// 	a.B.D.E.E1 = "a.B.D.E.E1"
+// 	entity := suite.CRUD.Read(&suite.Provider, &a)
+
+// 	initEntity := filterread.A{}
+// 	initEntity.B.D.E.E1 = "a.B.D.E.E1"
+// 	initEntity.B.D.E.E2 = "a.B.D.E.E2"
+
+// 	suite.Equal(types.EntityEqual(entity, &initEntity), true)
+// }
+
+// // empty presence container encoding error
+// // func (suite *FilterReadTestSuite) Test6() {
+// //     // `a.B.C` is an empty presence container
+// //     a := filterread.A{}
+// //     a.B.C = filterread.A_B_C{}
+// //     entity := suite.CRUD.Read(&suite.Provider, &a)
+//
+// //     initEntity := filterread.A{}
+// //     initEntity.B.C = filterread.A_B_C{}
+//
+// //     suite.Equal(types.EntityEqual(entity, &initEntity), true)
+// // }
+
+// func (suite *FilterReadTestSuite) Test7() {
+// 	// According to https://tools.ietf.org/html/rfc6241#section-6.2.5,
+// 	// `item1.Number`, `item2.Number` is a content match node.
+// 	a := filterread.A{}
+// 	item1 := filterread.A_Lst{}
+// 	item2 := filterread.A_Lst{}
+// 	item1.Number = 1
+// 	item2.Number = 2
+// 	a.Lst = append(a.Lst, item1)
+// 	a.Lst = append(a.Lst, item2)
+
+// 	entity := suite.CRUD.Read(&suite.Provider, &a)
+
+// 	initEntity := filterread.A{}
+// 	item1.Value = "l1.Value"
+// 	item2.Value = "l2.Value"
+// 	initEntity.Lst = append(initEntity.Lst, item1)
+// 	initEntity.Lst = append(initEntity.Lst, item2)
+
+// 	suite.Equal(types.EntityEqual(entity, &initEntity), true)
+// }
+
+// func (suite *FilterReadTestSuite) Test8() {
+// 	a := filterread.A{}
+// 	a.B.F = filterread.A_B_F{}
+// 	a.B.F.F1 = "a.B.F.F1"
+// 	entity := suite.CRUD.Read(&suite.Provider, &a)
+
+// 	initEntity := a
+
+// 	suite.Equal(types.EntityEqual(entity, &initEntity), true)
+// }
+
+func (suite *FilterReadTestSuite) BeforeTest(suiteName, testName string) {
+	fmt.Printf("%v: %v ...\n", suiteName, testName)
+}
+
+func TestFilterReadTestSuite(t *testing.T) {
+	suite.Run(t, new(FilterReadTestSuite))
+}

--- a/sdk/go/core/tests/filters_test.go
+++ b/sdk/go/core/tests/filters_test.go
@@ -1,0 +1,198 @@
+package test
+
+import (
+	"fmt"
+	ysanity "github.com/CiscoDevNet/ydk-go/ydk/models/ydktest/sanity"
+	"github.com/CiscoDevNet/ydk-go/ydk/providers"
+	"github.com/CiscoDevNet/ydk-go/ydk/services"
+	"github.com/CiscoDevNet/ydk-go/ydk/types"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type FiltersTestSuite struct {
+	suite.Suite
+	Provider providers.NetconfServiceProvider
+	CRUD     services.CrudService
+}
+
+func (suite *FiltersTestSuite) SetupSuite() {
+	suite.CRUD = services.CrudService{}
+	suite.Provider = providers.NetconfServiceProvider{
+		Address:  "127.0.0.1",
+		Username: "admin",
+		Password: "admin",
+		Port:     12022}
+	suite.Provider.Connect()
+}
+
+func (suite *FiltersTestSuite) TearDownSuite() {
+	suite.Provider.Disconnect()
+}
+
+func (suite *FiltersTestSuite) BeforeTest(suiteName, testName string) {
+	suite.CRUD.Delete(&suite.Provider, &ysanity.Runner{})
+	fmt.Printf("%v: %v ...\n", suiteName, testName)
+}
+
+func (suite *FiltersTestSuite) TestReadOnRefClass() {
+	r1 := ysanity.Runner{}
+	r1.One.Number = 1
+	r1.One.Name = "r1.One.Name"
+	suite.CRUD.Create(&suite.Provider, &r1)
+
+	r2 := ysanity.Runner{}
+	r2.One.Filter = types.Read
+	entity := suite.CRUD.Read(&suite.Provider, &r2)
+
+	suite.Equal(types.EntityEqual(entity, &r1), true)
+}
+
+// TODO: Encoding error if using YFilter for non-top level leaf
+// func (suite *FiltersTestSuite) TestReadOnLeaf() {
+//     r1 := ysanity.Runner{}
+//     r1.One.Number = 1
+//     r1.One.Name = "r1.One.Name"
+//     suite.CRUD.Create(&suite.Provider, &r1)
+
+//     r2 := ysanity.Runner{}
+//     r2.One.Number = types.Read
+//     entity := suite.CRUD.Read(&suite.Provider, &r2)
+
+//     suite.Equal(types.EntityEqual(entity, &r1), true)
+
+//     // r2.One.Number is a context match node:
+//     // https://tools.ietf.org/html/rfc6241#section-6.2.5
+//     // reads on r2.One.Number returns r2.One.Number and r2.One.Name
+//     r2 = ysanity.Runner{}
+//     r2.One.Number = 1
+//     entity = suite.CRUD.Read(&suite.Provider, &r2)
+//     suite.Equal(types.EntityEqual(entity, &r1), true)
+
+//     r2 = ysanity.Runner{}
+//     r2.One.Number = 2
+//     entity = suite.CRUD.Read(&suite.Provider, &r2)
+
+//     suite.Equal(types.EntityEqual(entity, &r2), true)
+// }
+
+// TODO: Encoding error if using YFilter for enum class
+// func (suite *FiltersTestSuite) TestReadOnRefEnumClass() {
+//     r1 := ysanity.Runner{}
+//     r1.Ytypes.BuiltInT.EnumValue = ysanity.YdkEnumTest_local
+//     suite.CRUD.Create(&suite.Provider, &r1)
+
+//     r2 := ysanity.Runner{}
+//     r2.Ytypes.BuiltInT.EnumValue = types.Read
+//     entity := suite.CRUD.Read(&suite.Provider, &r1)
+//     suite.Equal(types.EntityEqual(entity, &r1), true)
+// }
+
+// TODO: r2.OneList.Ldata is declared as []Runner_OneList_Ldata
+// not able to assign YFilter object to r2.OneList.Ldata
+// func (suite *FiltersTestSuite) TestReadOnRefList() {
+//     r1 := ysanity.Runner{}
+//     l1 := ysanity.Runner_OneList_Ldata{}
+//     l2 := ysanity.Runner_OneList_Ldata{}
+//     r1.OneList.Ldata = append(r1.OneList.Ldata, l1)
+//     r1.OneList.Ldata = append(r1.OneList.Ldata, l2)
+//     suite.CRUD.Create(&suite.Provider, &r1)
+
+//     r2 := ysanity.Runner{}
+
+//     // r2.OneList.Ldata = types.Read
+//     entity := suite.CRUD.Read(&suite.Provider, r2)
+
+//     suite.Equal(types.EntityEqual(entity, &r1), true)
+// }
+
+func (suite *FiltersTestSuite) TestReadOnListWithKey() {
+	r1 := ysanity.Runner{}
+	l1 := ysanity.Runner_OneList_Ldata{}
+	l2 := ysanity.Runner_OneList_Ldata{}
+	l1.Number = 1
+	l2.Number = 2
+	r1.OneList.Ldata = append(r1.OneList.Ldata, l1)
+	r1.OneList.Ldata = append(r1.OneList.Ldata, l2)
+	suite.CRUD.Create(&suite.Provider, &r1)
+
+	r2 := ysanity.Runner{}
+	r2.OneList.Ldata = append(r2.OneList.Ldata, l1)
+	entity := suite.CRUD.Read(&suite.Provider, &r2)
+
+	cmpEntity := ysanity.Runner{}
+	cmpEntity.OneList.Ldata = append(cmpEntity.OneList.Ldata, l1)
+
+	suite.Equal(types.EntityEqual(entity, &cmpEntity), true)
+}
+
+func (suite *FiltersTestSuite) TestReadOnLeaflist() {
+	r1 := ysanity.Runner{}
+	r1.Ytypes.BuiltInT.Llstring = append(r1.Ytypes.BuiltInT.Llstring, "1")
+	// TODO: leaf-list encoding error for old API using `GetEntityPath` method
+	// r1.Ytypes.BuiltInT.Llstring = append(r1.Ytypes.BuiltInT.Llstring, "2")
+	// r1.Ytypes.BuiltInT.Llstring = append(r1.Ytypes.BuiltInT.Llstring, "3")
+	suite.CRUD.Create(&suite.Provider, &r1)
+
+	r2 := ysanity.Runner{}
+	// TODO: r2.Ytypes.BuiltInT.Llstring is declared as []interface,
+	// how to use YFilter for leaf-list?
+	r2.Ytypes.BuiltInT.Llstring = append(r2.Ytypes.BuiltInT.Llstring, types.Read)
+	// r2.Ytypes.BuiltInT.Llstring = append(r2.Ytypes.BuiltInT.Llstring, "1")
+	entity := suite.CRUD.Read(&suite.Provider, &r2)
+
+	suite.Equal(types.EntityEqual(entity, &r2), true)
+}
+
+// TODO: Encoding error if using YFilter for identity ref
+// func (suite *FiltersTestSuite) TestReadOnIdentityRef() {
+//     r1 := ysanity.Runner{}
+//     r1.Ytypes.BuiltInT.IdentityRefValue = ysanity.Child_Identity{}
+//     suite.CRUD.Create(&suite.Provider, &r1)
+
+//     r2 := ysanity.Runner{}
+//     r2.Ytypes.BuiltInT.IdentityRefValue = types.Read
+//     entity := suite.CRUD.Read(&suite.Provider, &r2)
+//     suite.Equal(types.EntityEqual(entity, &r1), true)
+// }
+
+// TODO: Encoding error if using YFilter for non-top level leaf
+// func (suite *FiltersTestSuite) TestReadOnlyConfig() {
+//     r1 := ysanity.Runner{}
+//     r1.One.Number = 1
+//     r1.One.Name = "r1.One.Name"
+//     suite.CRUD.Create(&suite.Provider, &r1)
+
+//     r2 := ysanity.Runner{}
+//     r3 := ysanity.Runner{}
+
+//     r2.One.Number = types.Read
+//     r3.One.Number = types.Read
+
+//     entity2 := suite.CRUD.ReadConfig(&suite.Provider, &r2)
+//     entity3 := suite.CRUD.Read(&suite.Provider, &r3)
+
+//     r2Read := entity2.(*ysanity.Runner)
+//     r3Read := entity3.(*ysanity.Runner)
+
+//     suite.Equal(r2Read.One.Number, r3Read.One.Number)
+//     suite.Equal(r2Read.One.Name, r3Read.One.Name)
+// }
+
+func (suite *FiltersTestSuite) TestDecoder() {
+	r1 := ysanity.Runner{}
+	l := ysanity.Runner_OneList_Ldata{}
+	l.Number = 1
+	l.Name = "l.Name"
+	r1.OneList.Ldata = append(r1.OneList.Ldata, l)
+	suite.CRUD.Create(&suite.Provider, &r1)
+
+	r2 := ysanity.Runner{}
+	entity := suite.CRUD.Read(&suite.Provider, &r2)
+
+	suite.Equal(types.EntityEqual(entity, &r1), true)
+}
+
+func TestFiltersTestSuite(t *testing.T) {
+	suite.Run(t, new(FiltersTestSuite))
+}

--- a/ydkgen/printer/go/class_has_data_printer.py
+++ b/ydkgen/printer/go/class_has_data_printer.py
@@ -51,6 +51,9 @@ class ClassDataFilterPrinter(FunctionPrinter):
 
     def _get_conditions(self):
         conditions = []
+
+        conditions.append('{}.Filter != types.NotSet'.format(self.class_alias))
+
         line = '{0}.%s != nil'.format(self.class_alias)
         conditions.extend([line % l.go_name() for l in self.leafs if not l.is_many])
 

--- a/ydkgen/printer/go/class_printer.py
+++ b/ydkgen/printer/go/class_printer.py
@@ -56,6 +56,7 @@ class ClassPrinter(object):
     def _print_class_method_definitions(self, clazz, leafs, children):
         self._print_class_has_data(clazz, leafs, children)
         self._print_class_get_filter(clazz)
+        self._print_class_set_filter(clazz)
         self._print_class_get_segment_path(clazz)
         self._print_class_get_entity_path(clazz, leafs)
         self._print_class_get_child(clazz, leafs, children)
@@ -87,6 +88,13 @@ class ClassPrinter(object):
         fp = FunctionPrinter(self.ctx, clazz)
         fp.print_function_header_helper('GetFilter', return_type='types.YFilter')
         fp.ctx.writeln('return %s.Filter' % fp.class_alias)
+        fp.print_function_trailer()
+
+    # SetFilter
+    def _print_class_set_filter(self, clazz):
+        fp = FunctionPrinter(self.ctx, clazz)
+        fp.print_function_header_helper('SetFilter', args='yfilter types.YFilter')
+        fp.ctx.writeln('%s.Filter = yfilter' % fp.class_alias)
         fp.print_function_trailer()
 
     # GetSegmentPath


### PR DESCRIPTION
Commented out potential improvements:

Issues:

1. Empty presence container encoding error
2. Using YFilter for non-top level leaves
3. Using YFilter for `identity/identity-ref`
4. Using YFilter for Enums
5. YANG `leaf-list` encoding error(`C.CString` refers to old value, thus raises libyang duplicate value error)

Potential API changes:

1. Delete a particular leaf from `leaf-list` using YFilter
2. Delete whole YANG `list` or `leaf-list`(initialized as `[]interface`) using YFilter