### PR TITLE
macOS requires the libxml2 library, not the xml2 CLI tool

### DIFF
--- a/sdk/python/core/docsgen/getting_started.rst
+++ b/sdk/python/core/docsgen/getting_started.rst
@@ -38,7 +38,7 @@ It is required to install Xcode command line tools, `homebrew <http://brew.sh>`_
 
    $ xcode-select --install
    $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-   $ brew install python pkg-config libssh xml2 curl pcre cmake
+   $ brew install python pkg-config libssh libxml2 curl pcre cmake
    $ curl -O https://devhub.cisco.com/artifactory/osx-ydk/0.6.0/libydk_0.6.0_Darwin.pkg
    $ sudo installer -pkg libydk_0.6.0_Darwin.pkg -target /
 


### PR DESCRIPTION
Fixes: ImportError: No module named ydk.ext.entity_utils

Fixes #529  