### PR TITLE
Explicitly mention the cisco-ios-xe bundle is needed for XE platforms

### DIFF
--- a/sdk/python/core/docsgen/getting_started.rst
+++ b/sdk/python/core/docsgen/getting_started.rst
@@ -60,11 +60,12 @@ How to install
 ==============
 Quick Install
 -------------
-You can install the latest model packages from the Python package index.  Note that, in some systems, you need to install the new package as root.  You get a fully operational YDK environment by installing the ``cisco-ios-xr`` bundle which automatically installs all other YDK-related packages (``ydk``, ``cisco-ios-xr``, ``openconfig`` and ``ietf`` packages):
+You can install the latest model packages from the Python package index.  Note that, in some systems, you need to install the new package as root.  You get a fully operational YDK environment by installing the ``cisco-ios-xr`` and/or ``cisco-ios-xe`` bundle(s) (depending on whether you're developing for an IOS XR or IOS XE platform) which automatically installs all other YDK-related packages (``ydk``, ``openconfig`` and ``ietf`` packages):
 
 .. code-block:: sh
 
     $ pip install ydk-models-cisco-ios-xr
+    $ pip install ydk-models-cisco-ios-xe
 
 Alternatively, you can perform a partial installation.  If you only want to install the ``openconfig`` bundle and its dependencies (``ydk`` and ``ietf`` packages), execute:
 


### PR DESCRIPTION
Fixes #531 