### PR TITLE
Codec on demand fix

### DIFF
--- a/sdk/cpp/core/src/path/root_schema_node.cpp
+++ b/sdk/cpp/core/src/path/root_schema_node.cpp
@@ -237,13 +237,16 @@ ydk::path::RootSchemaNodeImpl::populate_new_schemas(std::vector<const lys_module
 void
 ydk::path::RootSchemaNodeImpl::populate_augmented_schema_nodes(const struct lys_module* module)
 {
-    for (int i = 0; i < module->augment_size; i++) {
+    for (int i = 0; i < module->augment_size; i++)
+    {
         auto aug = module->augment[i];
         std::vector<lys_node*> ancestors;
         lys_node* node = aug.target;
 
-        while(node) {
-            if (node->nodetype != LYS_USES) {
+        while(node)
+        {
+            if (node->nodetype != LYS_USES)
+            {
                 ancestors.emplace_back(node);
             }
             node = node->parent;
@@ -265,9 +268,27 @@ ydk::path::RootSchemaNodeImpl::populate_augmented_schema_node(std::vector<lys_no
     YLOG_DEBUG("Populating augmented schema node '{}'", std::string(target->name));
 
     lys_node* root = ancestors.back();
+    // quick fix: populate augmented top node if we have not already done so
+    bool found = false;
+    for (auto&c: m_children)
+    {
+        if (c->get_statement().arg == root->name)
+        {
+            found = true;
+            break;
+        }
+    }
+    if (found == false)
+    {
+        m_children.push_back(std::make_unique<SchemaNodeImpl>(this, const_cast<struct lys_node*>(root)));
+    }
+
+    // populate the rest of augmented schema nodes
     ancestors.pop_back();
-    for (auto& c: m_children) {
-        if (c->get_statement().arg == root->name) {
+    for (auto& c: m_children)
+    {
+        if (c->get_statement().arg == root->name)
+        {
             reinterpret_cast<SchemaNodeImpl*>(c.get())->populate_augmented_schema_node(ancestors, target);
         }
     }

--- a/sdk/cpp/tests/test_on_demand_loading.cpp
+++ b/sdk/cpp/tests/test_on_demand_loading.cpp
@@ -22,6 +22,9 @@
 //////////////////////////////////////////////////////////////////
 
 #include <string>
+#include <ydk/codec_provider.hpp>
+#include <ydk/codec_service.hpp>
+#include <ydk_ydktest/ietf_aug_base_1.hpp>
 #include "ydk/path_api.hpp"
 #include "config.hpp"
 #include "catch.hpp"
@@ -125,4 +128,12 @@ TEST_CASE("on_demand_loading_xml")
 
     auto cpython = codec.decode(root_schema, AUGMENTED_XML_PAYLOAD, ydk::EncodingFormat::XML);
     REQUIRE(cpython);
+}
+
+TEST_CASE("on_demand_provider_loading_xml")
+{
+    CodecServiceProvider codec_provider{EncodingFormat::XML};
+    CodecService codec_service{};
+    auto cpython = std::make_shared<ydktest::ietf_aug_base_1::Cpython>();
+    codec_service.decode(codec_provider, AUGMENTED_XML_PAYLOAD, cpython);
 }

--- a/sdk/python/core/tests/test_on_demand.py
+++ b/sdk/python/core/tests/test_on_demand.py
@@ -167,11 +167,15 @@ class SanityYang(unittest.TestCase):
 
     def test_on_demand_loading_xml(self):
         self.codec_provider.encoding = EncodingFormat.XML
-        self.codec.decode(self.codec_provider, AUGMENTED_XML_PAYLOAD)
+        entity1 = self.codec.decode(self.codec_provider, AUGMENTED_XML_PAYLOAD)
+        self.assertEqual(entity1.lib.ydktest_aug_4.ydktest_aug_nested_4.aug_four.get()=="aug four", True)
+
 
     def test_on_demand_loading_json(self):
         self.codec_provider.encoding = EncodingFormat.JSON
-        self.codec.decode(self.codec_provider, AUGMENTED_JSON_PAYLOAD)
+        entity1 = self.codec.decode(self.codec_provider, AUGMENTED_JSON_PAYLOAD)
+        self.assertEqual(entity1.doc.aug_5_identityref.get(), "ydktest-aug-ietf-5:aug-identity")
+
 
 
 if __name__ == '__main__':

--- a/sdk/python/core/ydk/providers/codec_provider.py
+++ b/sdk/python/core/ydk/providers/codec_provider.py
@@ -107,9 +107,7 @@ class CodecServiceProvider(object):
         name = bundle_name if not user_provided_repo else _USER_PROVIDED_REPO
         self.logger.log(_TRACE_LEVEL_NUM, "Initializing root schema for {}".format(name))
         # TODO: turn on and off libyang logging
-        # TODO: segmentation fault, unable to pass test_on_demand.py
-        # capabilities = []
-        capabilities = self._get_bundle_capabilities(bundle_name)
+        capabilities = []
         lookup_tables = self._get_bundle_capability_lookup_tables(bundle_name)
         self._root_schema_table[name] = repo.create_root_schema(lookup_tables, capabilities)
 


### PR DESCRIPTION
Sorry, seems like the [segfault error](https://github.com/CiscoDevNet/ydk-gen/compare/master...psykokwak4:master#diff-d6a37bbaf39a35396a54529527d5f0a3L110) comes from `ydk::path::RootSchemaNodeImpl::populate_augmented_schema_node`. It skipped root node insertion previously and we need to manually insert root node into `RootSchemaNode`. This error is not caused by Python/C++ conversion issue.
This request should fix Codec on demand loading on Python side, let me know if it works on real devices.
The C++ tests passed previously because it used path codec instead of `CodecServiceProvider`. I've added the missing test.