### PR TITLE
Remove &#13; from models pulled from devices

### DIFF
--- a/sdk/cpp/core/src/path/path.cpp
+++ b/sdk/cpp/core/src/path/path.cpp
@@ -112,6 +112,7 @@ std::string ydk::path::replace_xml_escape_sequences(const std::string& xml)
     seqs_table.push_back( std::make_pair( std::string("&gt;"),  std::string(">")) );
     seqs_table.push_back( std::make_pair( std::string("&amp;"), std::string("&")) );
     seqs_table.push_back( std::make_pair( std::string("&quot;"),std::string("""")) );
+    seqs_table.push_back( std::make_pair( std::string("&#13';"), std::string("")) );
 
     std::string reply = xml;
     for (std::pair<std::string,std::string> item : seqs_table)


### PR DESCRIPTION
As per https://communities.cisco.com/message/284424#284424 Huawei return &#13; as CR in their XML responses. This change strips them out.

I'm unsure if this needs a test adding? I'm uncertain how that would work.