### PR TITLE
Add dependencies needed for libydk with python3 on CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ sudo gdebi libydk-0.8.4-1.amd64.deb
 ```
 sudo yum install epel-release
 sudo yum install libssh-devel gcc-c++ python3-devel
+sudo yum install libtool libxml2-devel curl-devel pcre-devel libxslt-devel libssh-devel
 ```
 
 if your gcc compiler version is below 4.8.1, install gcc-5 and g++-5
@@ -144,6 +145,12 @@ sudo yum install centos-release-scl -y > /dev/null
 sudo yum install devtoolset-4-gcc* -y > /dev/null
 sudo ln -sf /opt/rh/devtoolset-4/root/usr/bin/gcc /usr/bin/gcc
 sudo ln -sf /opt/rh/devtoolset-4/root/usr/bin/g++ /usr/bin/g++
+```
+
+if your cmake is below version 3.0.0, uninstall it and install a newer version:
+```
+sudo yum remove cmake
+sudo yum install cmake3
 ```
 
 #### Install libydk library


### PR DESCRIPTION
Generating, building and installing `libydk` fails with python 3.6.8 on CentOS 7:
```
cd ydk-gen
python3 ./generate.py --libydk
[...]
Error:
  CMake 3.0.0 or higher is required.  You are running version 2.8.12.2
```

The solution is:
```
sudo yum remove cmake
sudo yum install cmake3
```

Furthermore, CMake then states that it cannot find various libraries with most of the errors having the following form:
```
Could NOT find LibXml2 (missing: LIBXML2_LIBRARIES LIBXML2_INCLUDE_DIR)
```

The solution is:
```
sudo yum install libtool libxml2-devel curl-devel pcre-devel libxslt-devel libssh-devel
```