### PR TITLE
Fix logging message

### DIFF
--- a/sdk/cpp/core/src/netconf_session.cpp
+++ b/sdk/cpp/core/src/netconf_session.cpp
@@ -555,7 +555,7 @@ static string get_netconf_payload(path::DataNode & input, const string &  data_t
 
 static string extract_rpc_error(const string & reply)
 {
-    string msg = "RPC error occurred; check log file for details";
+    string msg = "RPC error occurred; check log for details";
     auto error_tag_pos = reply.find("<error-message");
     auto error_tag_close_pos = reply.find("</error-message>");
     if (error_tag_pos != string::npos && error_tag_close_pos != string::npos)


### PR DESCRIPTION
Error message now points user to "log" instead of "log file".  The new text is more generic and doesn't create a confusion when logging is  just directed to stderr.