### PR TITLE
Version numbers in bundle resolver to comply with PEP 440

### DIFF
--- a/ydkgen/resolver/bundle_resolver.py
+++ b/ydkgen/resolver/bundle_resolver.py
@@ -28,6 +28,7 @@ from shutil import rmtree, copy
 from collections import namedtuple, defaultdict
 from .bundle_translator import translate
 from ..common import YdkGenException
+from packaging.version import Version
 
 
 logger = logging.getLogger('ydkgen')
@@ -38,7 +39,6 @@ Local = namedtuple('Local', ['url'])
 Remote = namedtuple('Remote', ['url', 'commitid', 'path'])
 RepoDir = namedtuple('RepoDir', ['repo', 'dir'])
 Bundles = namedtuple('Bundles', ['curr_bundle', 'bundles'])
-Version = namedtuple('Version', ['major', 'minor', 'patch'])
 
 
 def nested_defaultdict():
@@ -81,8 +81,8 @@ class BundleDefinition(object):
 
     def __init__(self, data):
         self._name = data['name'].replace('-', '_')
-        self._version = Version(*tuple(data['version'].split('.')))
-        self._core_version = Version(*tuple(data['core-version'].split('.')))
+        self._version = Version(data['version'])
+        self._core_version = Version(data['core-version'])
         self._description = data['description'] if 'description' in data else str()
         self._long_description = data['long-description'] if 'long-description' in data else str()
 
@@ -108,12 +108,12 @@ class BundleDefinition(object):
     @property
     def str_version(self):
         """ Return string representation of version."""
-        return "%s.%s.%s" % self.version
+        return str(self.version)
 
     @property
     def str_core_version(self):
         """ Return string representation of ydk version."""
-        return "%s.%s.%s" % self.core_version
+        return str(self.core_version)
 
     @property
     def description(self):


### PR DESCRIPTION
YDK-gen tag 0.8.4 produces this error:
```bash
./generate.py -v --python --bundle /tmp/tmpc6kf25w3/ydk-models-wireless.json
YDKGEN_HOME not set. Assuming current directory is working directory.
Bundle Translator: Cloning from https://github.com/YangModels/yang.git --> /tmp/tmpaqaxfqew.yang
Bundle Translator: Removing folder /tmp/tmpaqaxfqew.yang
Resolving file tmp3f57l_6d.bundle --> /nobackup/pyats/projects/ydk-gen/gen-api/.cache/bundles
Traceback (most recent call last):
  File "./generate.py", line 492, in <module>
    output_directory = (generator.generate(options.bundle))
  File "/nobackup/pyats/projects/ydk-gen/ydkgen/__init__.py", line 93, in generate
    return self._generate_bundle(description_file)
  File "/nobackup/pyats/projects/ydk-gen/ydkgen/__init__.py", line 123, in _generate_bundle
    curr_bundle, all_bundles = resolver.resolve(tmp_file)
  File "/nobackup/pyats/projects/ydk-gen/ydkgen/resolver/bundle_resolver.py", line 304, in resolve
    root = Bundle(bundle_file, self.cached_models_dir, self.iskeyword)
  File "/nobackup/pyats/projects/ydk-gen/ydkgen/resolver/bundle_resolver.py", line 232, in __init__
    super().__init__(data['bundle'])
  File "/nobackup/pyats/projects/ydk-gen/ydkgen/resolver/bundle_resolver.py", line 84, in __init__
    self._version = Version(*tuple(data['version'].split('.')))
TypeError: __new__() takes 4 positional arguments but 5 were given
```
/tmp/tmpc6kf25w3/ydk-models-wireless.json was:
```json
{
  "author": "Cisco",
  "copyright": "Cisco",
  "description": "YDK bundle for wireless testing",
  "models": {
    "file": [
      "/absolute_path/Cisco-IOS-XE-wireless-enum-types.yang",
      "/absolute_path/Cisco-IOS-XE-wireless-types.yang",
      "/absolute_path/Cisco-IOS-XE-wireless-wlan-cfg.yang",
      "/absolute_path/cisco-semver.yang"
    ],
    "git": [
      {
        "commits": [
          {
            "file": [
              "standard/ietf/RFC/ietf-inet-types.yang",
              "standard/ietf/RFC/ietf-yang-types.yang"
            ]
          }
        ],
        "url": "https://github.com/YangModels/yang.git"
      }
    ]
  },
  "name": "wireless",
  "version": "17.4.0.20200623001943"
}
```
I tested this with pep440.is_canonical() and it tells me it's well formed. Same error with the followings:
```
17.4.0.dev20200702092331
17.4.0.post20200702092331
0.1.5.post1
```
So looking at PEP 440 format should be:
```
[N!]N(.N)*[{a|b|rc}N][.postN][.devN]
```
and I believe there's an error on how the release segment "N(.N)*" is parsed.