### PR TITLE
Fix #1098.  Support for parsing JSON capabilities.

### DIFF
--- a/sdk/cpp/core/src/capabilities_parser.cpp
+++ b/sdk/cpp/core/src/capabilities_parser.cpp
@@ -26,6 +26,14 @@ CapabilitiesXmlParser::~CapabilitiesXmlParser()
 {
 }
 
+CapabilitiesJsonParser::CapabilitiesJsonParser()
+{
+}
+
+CapabilitiesJsonParser::~CapabilitiesJsonParser()
+{
+}
+
 CapabilitiesParser::CapabilitiesParser()
 {
 }

--- a/sdk/cpp/core/src/capabilities_parser.hpp
+++ b/sdk/cpp/core/src/capabilities_parser.hpp
@@ -36,6 +36,15 @@ class CapabilitiesXmlParser
         virtual std::vector<std::string> parse(const std::string & capabilities_xml) = 0;
 };
 
+class CapabilitiesJsonParser
+{
+    public:
+        CapabilitiesJsonParser();
+        virtual ~CapabilitiesJsonParser();
+
+        virtual std::vector<std::string> parse(const std::string & capabilities_json) = 0;
+};
+
 class CapabilitiesParser
 {
     public:

--- a/sdk/cpp/core/src/ietf_parser.cpp
+++ b/sdk/cpp/core/src/ietf_parser.cpp
@@ -22,9 +22,10 @@
 #include "path_api.hpp"
 #include "xml_util.hpp"
 #include "ydk_yang.hpp"
-
+#include "json.hpp"
 
 using namespace std;
+using json = nlohmann::json;
 
 namespace ydk
 {
@@ -224,6 +225,46 @@ vector<string> IetfCapabilitiesXmlParser::parse(const string & capabilities_buff
         }
         cur = cur->next;
     }
+    return capabilities;
+}
+
+//////////////////////////////////////////
+//// IetfCapabilitiesJsonParser
+//////////////////////////////////////////
+IetfCapabilitiesJsonParser::IetfCapabilitiesJsonParser()
+{
+}
+
+IetfCapabilitiesJsonParser::~IetfCapabilitiesJsonParser()
+{
+}
+
+vector<string> IetfCapabilitiesJsonParser::parse_yang_1_1(const std::string & buffer)
+{
+    return parse(buffer);
+}
+
+vector<string> IetfCapabilitiesJsonParser::parse(const std::string & buffer)
+{
+    std::vector<std::string> capabilities{};
+    
+    auto j = json::parse(buffer);
+    
+    if (j.find("ietf-restconf-monitoring:capabilities") != j.end())
+    {
+        auto& caps = j["ietf-restconf-monitoring:capabilities"];
+        if (caps.find("capability") != caps.end())
+        {
+            auto& cap = caps["capability"];
+            if (cap.size() > 0)
+            {
+                for (auto& c : cap) {
+                    capabilities.push_back(c);
+                }
+            }
+        }
+    }
+    
     return capabilities;
 }
 

--- a/sdk/cpp/core/src/ietf_parser.hpp
+++ b/sdk/cpp/core/src/ietf_parser.hpp
@@ -43,6 +43,17 @@ class IetfCapabilitiesXmlParser : public CapabilitiesXmlParser
 };
 
 
+class IetfCapabilitiesJsonParser : public CapabilitiesJsonParser
+{
+    public:
+        IetfCapabilitiesJsonParser();
+        ~IetfCapabilitiesJsonParser();
+
+        std::vector<std::string> parse(const std::string & buffer);
+        std::vector<std::string> parse_yang_1_1(const std::string & buffer);
+};
+
+
 class IetfCapabilitiesParser : public CapabilitiesParser
 {
     public:

--- a/sdk/cpp/core/src/path_api.hpp
+++ b/sdk/cpp/core/src/path_api.hpp
@@ -1139,7 +1139,7 @@ class RestconfSession : public Session {
     std::shared_ptr<DataNode> invoke(DataNode& rpc) const;
 
   private:
-    void initialize(Repository & repo);
+    void initialize(Repository & repo, EncodingFormat encoding);
     std::shared_ptr<DataNode> handle_crud_edit(Rpc& rpc, const std::string & yfilter) const;
     std::shared_ptr<DataNode> handle_crud_read(Rpc& rpc) const;
 


### PR DESCRIPTION
Add a CapabilitiesJsonParser for parsing RESTCONF capabilities when JSON encoding is specified.

Add IetfCapabilitiesJsonParser to parse capabilities YANG model defined by ietf-restconf-monitoring:capabilities using JSON encoding.  This parses uses included nlohmann::json library.

Add EncodingFormat parameter to RestconfSession::initialize method to enable use of JSON capabilities parser.

The RESTCONF Protocol (RFC 8040) section 5.2 specifies that a server MUST support one of either XML or JSON encoding.  A server MAY support both and a client will need to support both XML and JSON. Link: https://datatracker.ietf.org/doc/html/rfc8040#section-5.2.